### PR TITLE
Support for refitting LA with option to override or update

### DIFF
--- a/laplace/baselaplace.py
+++ b/laplace/baselaplace.py
@@ -181,7 +181,7 @@ class BaseLaplace:
     def optimize_prior_precision_base(self, pred_type, method='marglik', n_steps=100, lr=1e-1,
                                       init_prior_prec=1., val_loader=None, loss=get_nll,
                                       log_prior_prec_min=-4, log_prior_prec_max=4, grid_size=100,
-                                      link_approx='probit', n_samples=100, verbose=False, 
+                                      link_approx='probit', n_samples=100, verbose=False,
                                       cv_loss_with_var=False):
         """Optimize the prior precision post-hoc using the `method`
         specified by the user.
@@ -334,11 +334,11 @@ class ParametricLaplace(BaseLaplace):
         try:
             self._init_H()
         except AttributeError:  # necessary information not yet available
-            pass  
+            pass
         self.loss = 0
         self.n_data = 0
         # posterior mean/mode
-        self.mean = self.prior_mean 
+        self.mean = self.prior_mean
 
     def _init_H(self):
         raise NotImplementedError
@@ -359,7 +359,7 @@ class ParametricLaplace(BaseLaplace):
             self._init_H()
             self.loss = 0
             self.n_data = 0
-            
+
         self.model.eval()
         self.mean = parameters_to_vector(self.model.parameters()).detach()
 
@@ -445,7 +445,7 @@ class ParametricLaplace(BaseLaplace):
 
     def log_prob(self, value):
         """Compute the log probability under the (current) Laplace approximation.
-        
+
         Returns
         -------
         log_prob : torch.Tensor
@@ -638,7 +638,7 @@ class ParametricLaplace(BaseLaplace):
     def optimize_prior_precision(self, method='marglik', pred_type='glm', n_steps=100, lr=1e-1,
                                  init_prior_prec=1., val_loader=None, loss=get_nll,
                                  log_prior_prec_min=-4, log_prior_prec_max=4, grid_size=100,
-                                 link_approx='probit', n_samples=100, verbose=False, 
+                                 link_approx='probit', n_samples=100, verbose=False,
                                  cv_loss_with_var=False):
         assert pred_type in ['glm', 'nn']
         self.optimize_prior_precision_base(pred_type, method, n_steps, lr,
@@ -727,7 +727,7 @@ class FullLaplace(ParametricLaplace):
     @property
     def log_det_posterior_precision(self):
         return self.posterior_precision.logdet()
-    
+
     def square_norm(self, value):
         delta = value - self.mean
         return delta @ self.posterior_precision @ delta
@@ -819,7 +819,7 @@ class KronLaplace(ParametricLaplace):
     def square_norm(self, value):
         delta = value - self.mean
         if type(self.H) is Kron:  # fall back to prior
-            return (delta * self.posterior_precision)
+            return (delta * self.posterior_precision) @ delta
         return delta @ self.posterior_precision.bmm(delta, exponent=1)
 
     def functional_variance(self, Js):

--- a/laplace/baselaplace.py
+++ b/laplace/baselaplace.py
@@ -806,17 +806,20 @@ class KronLaplace(ParametricLaplace):
         -------
         precision : `laplace.matrix.KronDecomposed`
         """
-        if type(self.H) is Kron:
-            # decompose first
-            return self.H.decompose() * self._H_factor + self.prior_precision
+        if type(self.H) is Kron:  # Fall back to prior
+            return self.prior_precision_diag
         return self.H * self._H_factor + self.prior_precision
 
     @property
     def log_det_posterior_precision(self):
+        if type(self.H) is Kron:  # Fall back to diag prior
+            return self.posterior_precision.log().sum()
         return self.posterior_precision.logdet()
 
     def square_norm(self, value):
         delta = value - self.mean
+        if type(self.H) is Kron:  # fall back to prior
+            return (delta * self.posterior_precision)
         return delta @ self.posterior_precision.bmm(delta, exponent=1)
 
     def functional_variance(self, Js):

--- a/laplace/baselaplace.py
+++ b/laplace/baselaplace.py
@@ -443,13 +443,21 @@ class ParametricLaplace(BaseLaplace):
         """
         raise NotImplementedError
 
-    def log_prob(self, value):
+    def log_prob(self, value, normalized=True):
         """Compute the log probability under the (current) Laplace approximation.
+
+        Parameters
+        ----------
+        normalized : bool, default=True
+            whether to return log of a properly normalized Gaussian or just the
+            terms that depend on `value`.
 
         Returns
         -------
         log_prob : torch.Tensor
         """
+        if not normalized:
+            return - self.square_norm(value) / 2
         log_prob = - self.n_params / 2 * log(2 * pi) + self.log_det_posterior_precision / 2
         log_prob -= self.square_norm(value) / 2
         return log_prob
@@ -806,20 +814,18 @@ class KronLaplace(ParametricLaplace):
         -------
         precision : `laplace.matrix.KronDecomposed`
         """
-        if type(self.H) is Kron:  # Fall back to prior
-            return self.prior_precision_diag
         return self.H * self._H_factor + self.prior_precision
 
     @property
     def log_det_posterior_precision(self):
         if type(self.H) is Kron:  # Fall back to diag prior
-            return self.posterior_precision.log().sum()
+            return self.prior_precision_diag.log().sum()
         return self.posterior_precision.logdet()
 
     def square_norm(self, value):
         delta = value - self.mean
         if type(self.H) is Kron:  # fall back to prior
-            return (delta * self.posterior_precision) @ delta
+            return (delta * self.prior_precision_diag) @ delta
         return delta @ self.posterior_precision.bmm(delta, exponent=1)
 
     def functional_variance(self, Js):

--- a/laplace/baselaplace.py
+++ b/laplace/baselaplace.py
@@ -1,4 +1,4 @@
-from math import sqrt, pi
+from math import sqrt, pi, log
 import numpy as np
 import torch
 from torch.nn.utils import parameters_to_vector, vector_to_parameters
@@ -60,7 +60,7 @@ class BaseLaplace:
         # log likelihood = g(loss)
         self.loss = 0.
         self.n_outputs = None
-        self.n_data = None
+        self.n_data = 0
 
     @property
     def backend(self):
@@ -70,9 +70,6 @@ class BaseLaplace:
         return self._backend
 
     def _curv_closure(self, X, y, N):
-        raise NotImplementedError
-
-    def _check_fit(self):
         raise NotImplementedError
 
     def fit(self, train_loader):
@@ -92,8 +89,6 @@ class BaseLaplace:
         -------
         log_likelihood : torch.Tensor
         """
-        self._check_fit()
-
         factor = - self._H_factor
         if self.likelihood == 'regression':
             # loss used is just MSE, need to add normalizer for gaussian likelihood
@@ -336,20 +331,19 @@ class ParametricLaplace(BaseLaplace):
             'GGN or EF backends required in ParametricLaplace.'
         super().__init__(model, likelihood, sigma_noise, prior_precision,
                          prior_mean, temperature, backend, backend_kwargs)
-
-        self.H = None
-
+        try:
+            self._init_H()
+        except AttributeError:  # necessary information not yet available
+            pass  
+        self.loss = 0
+        self.n_data = 0
         # posterior mean/mode
-        self.mean = parameters_to_vector(self.model.parameters()).detach()
+        self.mean = self.prior_mean 
 
     def _init_H(self):
         raise NotImplementedError
 
-    def _check_fit(self):
-        if self.H is None:
-            raise AttributeError('ParametricLaplace not fitted. Run fit() first.')
-
-    def fit(self, train_loader):
+    def fit(self, train_loader, override=True):
         """Fit the local Laplace approximation at the parameters of the model.
 
         Parameters
@@ -357,13 +351,17 @@ class ParametricLaplace(BaseLaplace):
         train_loader : torch.data.utils.DataLoader
             each iterate is a training batch (X, y);
             `train_loader.dataset` needs to be set to access \\(N\\), size of the data set
+        override : bool, default=True
+            whether to initialize H, loss, and n_data again; setting to False is useful for
+            online learning settings to accumulate a sequential posterior approximation.
         """
-        if self.H is not None:
-            raise ValueError('Already fit.')
-
-        self._init_H()
-
+        if override:
+            self._init_H()
+            self.loss = 0
+            self.n_data = 0
+            
         self.model.eval()
+        self.mean = parameters_to_vector(self.model.parameters()).detach()
 
         X, _ = next(iter(train_loader))
         with torch.no_grad():
@@ -382,7 +380,7 @@ class ParametricLaplace(BaseLaplace):
             self.loss += loss_batch
             self.H += H_batch
 
-        self.n_data = N
+        self.n_data += N
 
     @property
     def scatter(self):
@@ -434,6 +432,28 @@ class ParametricLaplace(BaseLaplace):
         """
         return self.log_det_posterior_precision - self.log_det_prior_precision
 
+    def square_norm(self, value):
+        """Compute the square norm under post. Precision with `value-self.mean` as 𝛥:
+        \\[
+            \\Delta^\top P \\Delta
+        \\]
+        Returns
+        -------
+        square_form
+        """
+        raise NotImplementedError
+
+    def log_prob(self, value):
+        """Compute the log probability under the (current) Laplace approximation.
+        
+        Returns
+        -------
+        log_prob : torch.Tensor
+        """
+        log_prob = - self.n_params / 2 * log(2 * pi) + self.log_det_posterior_precision / 2
+        log_prob -= self.square_norm(value) / 2
+        return log_prob
+
     def log_marginal_likelihood(self, prior_precision=None, sigma_noise=None):
         """Compute the Laplace approximation to the log marginal likelihood subject
         to specific Hessian approximations that subclasses implement.
@@ -454,9 +474,6 @@ class ParametricLaplace(BaseLaplace):
         -------
         log_marglik : torch.Tensor
         """
-        # make sure we can differentiate wrt prior and sigma_noise for regression
-        self._check_fit()
-
         # update prior precision (useful when iterating on marglik)
         if prior_precision is not None:
             self.prior_precision = prior_precision
@@ -497,8 +514,6 @@ class ParametricLaplace(BaseLaplace):
             For `likelihood='regression'`, a tuple of torch.Tensor is returned
             with the mean and the predictive variance.
         """
-        self._check_fit()
-
         if pred_type not in ['glm', 'nn']:
             raise ValueError('Only glm and nn supported as prediction types.')
 
@@ -555,8 +570,6 @@ class ParametricLaplace(BaseLaplace):
         samples : torch.Tensor
             samples `(n_samples, batch_size, output_shape)`
         """
-        self._check_fit()
-
         if pred_type not in ['glm', 'nn']:
             raise ValueError('Only glm and nn supported as prediction types.')
 
@@ -667,6 +680,10 @@ class FullLaplace(ParametricLaplace):
     def _curv_closure(self, X, y, N):
         return self.backend.full(X, y, N=N)
 
+    def fit(self, train_loader, override=True):
+        self._posterior_scale = None
+        return super().fit(train_loader, override=override)
+
     def _compute_scale(self):
         self._posterior_scale = invsqrt_precision(self.posterior_precision)
 
@@ -705,12 +722,15 @@ class FullLaplace(ParametricLaplace):
         precision : torch.tensor
             `(parameters, parameters)`
         """
-        self._check_fit()
         return self._H_factor * self.H + torch.diag(self.prior_precision_diag)
 
     @property
     def log_det_posterior_precision(self):
         return self.posterior_precision.logdet()
+    
+    def square_norm(self, value):
+        delta = value - self.mean
+        return delta @ self.posterior_precision @ delta
 
     def functional_variance(self, Js):
         return torch.einsum('ncp,pq,nkq->nck', Js, self.posterior_covariance, Js)
@@ -739,6 +759,7 @@ class KronLaplace(ParametricLaplace):
                  prior_mean=0., temperature=1., backend=BackPackGGN, damping=False,
                  **backend_kwargs):
         self.damping = damping
+        self.H_facs = None
         super().__init__(model, likelihood, sigma_noise, prior_precision,
                          prior_mean, temperature, backend, **backend_kwargs)
 
@@ -748,12 +769,34 @@ class KronLaplace(ParametricLaplace):
     def _curv_closure(self, X, y, N):
         return self.backend.kron(X, y, N=N)
 
-    def fit(self, train_loader, keep_factors=False):
-        super().fit(train_loader)
-        # Kron requires postprocessing as all quantities depend on the decomposition.
-        if keep_factors:
+    @staticmethod
+    def _rescale_factors(kron, factor):
+        for F in kron.kfacs:
+            if len(F) == 2:
+                F[1] *= factor
+        return kron
+
+    def fit(self, train_loader, override=True):
+        if override:
+            self.H_facs = None
+
+        if self.H_facs is not None:
+            n_data_old = self.n_data
+            n_data_new = len(train_loader.dataset)
+            self._init_H()  # re-init H non-decomposed
+            # discount previous Kronecker factors to sum up properly together with new ones
+            self.H_facs = self._rescale_factors(self.H_facs, n_data_old / (n_data_old + n_data_new))
+
+        super().fit(train_loader, override=override)
+
+        if self.H_facs is None:
             self.H_facs = self.H
-        self.H = self.H.decompose(damping=self.damping)
+        else:
+            # discount new factors that were computed assuming N = n_data_new
+            self.H = self._rescale_factors(self.H, n_data_new / (n_data_new + n_data_old))
+            self.H_facs += self.H
+        # Decompose to self.H for all required quantities but keep H_facs for further inference
+        self.H = self.H_facs.decompose(damping=self.damping)
 
     @property
     def posterior_precision(self):
@@ -763,12 +806,18 @@ class KronLaplace(ParametricLaplace):
         -------
         precision : `laplace.matrix.KronDecomposed`
         """
-        self._check_fit()
+        if type(self.H) is Kron:
+            # decompose first
+            return self.H.decompose() * self._H_factor + self.prior_precision
         return self.H * self._H_factor + self.prior_precision
 
     @property
     def log_det_posterior_precision(self):
         return self.posterior_precision.logdet()
+
+    def square_norm(self, value):
+        delta = value - self.mean
+        return delta @ self.posterior_precision.bmm(delta, exponent=1)
 
     def functional_variance(self, Js):
         return self.posterior_precision.inv_square_form(Js)
@@ -810,7 +859,6 @@ class DiagLaplace(ParametricLaplace):
         precision : torch.tensor
             `(parameters)`
         """
-        self._check_fit()
         return self._H_factor * self.H + self.prior_precision_diag
 
     @property
@@ -838,6 +886,10 @@ class DiagLaplace(ParametricLaplace):
     @property
     def log_det_posterior_precision(self):
         return self.posterior_precision.log().sum()
+
+    def square_norm(self, value):
+        delta = value - self.mean
+        return delta @ (delta * self.posterior_precision)
 
     def functional_variance(self, Js: torch.Tensor) -> torch.Tensor:
         self._check_jacobians(Js)

--- a/laplace/baselaplace.py
+++ b/laplace/baselaplace.py
@@ -335,8 +335,6 @@ class ParametricLaplace(BaseLaplace):
             self._init_H()
         except AttributeError:  # necessary information not yet available
             pass
-        self.loss = 0
-        self.n_data = 0
         # posterior mean/mode
         self.mean = self.prior_mean
 

--- a/laplace/lllaplace.py
+++ b/laplace/lllaplace.py
@@ -65,21 +65,21 @@ class LLLaplace(ParametricLaplace):
                          backend_kwargs=backend_kwargs)
         self.model = FeatureExtractor(deepcopy(model), last_layer_name=last_layer_name)
         if self.model.last_layer is None:
-            self.mean = None
+            self.mean = prior_mean
             self.n_params = None
             self.n_layers = None
             # ignore checks of prior mean setter temporarily, check on .fit()
             self._prior_precision = prior_precision
             self._prior_mean = prior_mean
         else:
-            self.mean = parameters_to_vector(self.model.last_layer.parameters()).detach()
-            self.n_params = len(self.mean)
+            self.mean = prior_mean 
+            self.n_params = len(parameters_to_vector(self.model.last_layer.parameters()))
             self.n_layers = len(list(self.model.last_layer.parameters()))
             self.prior_precision = prior_precision
             self.prior_mean = prior_mean
         self._backend_kwargs['last_layer'] = True
 
-    def fit(self, train_loader):
+    def fit(self, train_loader, override=True):
         """Fit the local Laplace approximation at the parameters of the model.
 
         Parameters
@@ -87,10 +87,10 @@ class LLLaplace(ParametricLaplace):
         train_loader : torch.data.utils.DataLoader
             each iterate is a training batch (X, y);
             `train_loader.dataset` needs to be set to access \\(N\\), size of the data set
+        override : bool, default=True
+            whether to initialize H, loss, and n_data again; setting to False is useful for
+            online learning settings to accumulate a sequential posterior approximation.
         """
-        if self.H is not None:
-            raise ValueError('Already fit.')
-
         self.model.eval()
 
         if self.model.last_layer is None:
@@ -100,14 +100,19 @@ class LLLaplace(ParametricLaplace):
                     self.model.find_last_layer(X[:1].to(self._device))
                 except (TypeError, AttributeError):
                     self.model.find_last_layer(X.to(self._device))
-            self.mean = parameters_to_vector(self.model.last_layer.parameters()).detach()
-            self.n_params = len(self.mean)
+            params = parameters_to_vector(self.model.last_layer.parameters()).detach()
+            self.n_params = len(params)
             self.n_layers = len(list(self.model.last_layer.parameters()))
             # here, check the already set prior precision again
             self.prior_precision = self._prior_precision
             self.prior_mean = self._prior_mean
+            self._init_H()
 
-        super().fit(train_loader)
+        if override:
+            self._init_H()
+
+        super().fit(train_loader, override=override)
+        self.mean = parameters_to_vector(self.model.last_layer.parameters()).detach()
 
     def _glm_predictive_distribution(self, X):
         Js, f_mu = self.backend.last_layer_jacobians(self.model, X)

--- a/laplace/lllaplace.py
+++ b/laplace/lllaplace.py
@@ -72,11 +72,11 @@ class LLLaplace(ParametricLaplace):
             self._prior_precision = prior_precision
             self._prior_mean = prior_mean
         else:
-            self.mean = prior_mean 
             self.n_params = len(parameters_to_vector(self.model.last_layer.parameters()))
             self.n_layers = len(list(self.model.last_layer.parameters()))
             self.prior_precision = prior_precision
             self.prior_mean = prior_mean
+            self.mean = self.prior_mean 
         self._backend_kwargs['last_layer'] = True
 
     def fit(self, train_loader, override=True):

--- a/tests/test_baselaplace.py
+++ b/tests/test_baselaplace.py
@@ -1,8 +1,13 @@
+from math import sqrt
+from _pytest.mark import param
+from laplace.matrix import KronDecomposed
 import pytest
 from itertools import product
 import numpy as np
+from copy import deepcopy
 import torch
 from torch import nn
+from torch.distributions.multivariate_normal import MultivariateNormal
 from torch.nn.utils import parameters_to_vector
 from torch.utils.data import DataLoader, TensorDataset
 from torch.distributions import Normal, Categorical
@@ -118,7 +123,7 @@ def test_laplace_init_precision(laplace, model):
 
 
 @pytest.mark.parametrize('laplace', flavors)
-def test_laplace_init_prior_mean_and_scatter(laplace, model):
+def test_laplace_init_prior_mean_and_scatter(laplace, model, class_loader):
     mean = parameters_to_vector(model.parameters())
     P = len(mean)
     lap_scalar_mean = laplace(model, 'classification',
@@ -133,8 +138,14 @@ def test_laplace_init_prior_mean_and_scatter(laplace, model):
     lap_tensor_full_mean = laplace(model, 'classification',
                                    prior_precision=1e-2, prior_mean=torch.ones(P))
     assert torch.allclose(lap_tensor_full_mean.prior_mean, torch.ones(P))
-    expected = ((mean - 1) * 1e-2) @ (mean - 1)
-    assert expected.ndim == 0
+
+    lap_scalar_mean.fit(class_loader)
+    lap_tensor_mean.fit(class_loader)
+    lap_tensor_scalar_mean.fit(class_loader)
+    lap_tensor_full_mean.fit(class_loader)
+    expected = torch.tensor(0).reshape(-1)
+    # assert expected.ndim == 0
+    expected = ((mean -1) * 1e-2) @ (mean -1)
     assert torch.allclose(lap_scalar_mean.scatter, expected)
     assert lap_scalar_mean.scatter.shape == expected.shape
     assert torch.allclose(lap_tensor_mean.scatter, expected)
@@ -208,7 +219,6 @@ def test_laplace_functionality(laplace, lh, model, reg_loader, class_loader):
     prior_prec = torch.diag(lap.prior_precision_diag)
     assert prior_prec.shape == torch.Size([len(theta), len(theta)])
     lml = lml - 1/2 * theta @ prior_prec @ theta
-    Sigma_0 = torch.inverse(prior_prec)
     if laplace == DiagLaplace:
         log_det_post_prec = lap.posterior_precision.log().sum()
     else:
@@ -224,7 +234,7 @@ def test_laplace_functionality(laplace, lh, model, reg_loader, class_loader):
     assert samples.shape == torch.Size([1000000, len(theta)])
     mu_comp = samples.mean(dim=0)
     mu_true = lap.mean
-    assert torch.allclose(mu_comp, mu_true, rtol=1)
+    assert torch.allclose(mu_comp, mu_true, atol=1e-2)
 
     # test functional variance
     if laplace == FullLaplace:
@@ -237,6 +247,70 @@ def test_laplace_functionality(laplace, lh, model, reg_loader, class_loader):
     true_f_var = torch.einsum('mkp,pq,mcq->mkc', Js, Sigma, Js)
     comp_f_var = lap.functional_variance(Js)
     assert torch.allclose(true_f_var, comp_f_var, rtol=1e-4)
+
+
+@pytest.mark.parametrize('laplace', flavors)
+def test_overriding_fit(laplace, model, reg_loader):
+    lap = laplace(model, 'regression', sigma_noise=0.3, prior_precision=0.7)
+    lap.fit(reg_loader)
+    if type(lap.posterior_precision) is KronDecomposed:
+        P = lap.posterior_precision.to_matrix()
+    else:
+        P = lap.posterior_precision.clone()
+    m = lap.mean.clone()
+    marglik = lap.log_marginal_likelihood().detach().clone()
+    assert lap.n_data == len(reg_loader.dataset)
+    lap.fit(reg_loader, override=True)
+    assert torch.allclose(lap.mean, m)
+    if type(lap.posterior_precision) is KronDecomposed:
+        assert torch.allclose(lap.posterior_precision.to_matrix(), P)
+    else:
+        assert torch.allclose(lap.posterior_precision, P)
+    assert torch.allclose(marglik, lap.log_marginal_likelihood())
+    assert lap.n_data == len(reg_loader.dataset)
+
+
+@pytest.mark.parametrize('laplace', flavors)
+def test_online_fit(laplace, model, reg_loader):
+    lap = laplace(model, 'regression', sigma_noise=0.3, prior_precision=0.7)
+    lap.fit(reg_loader)
+    if type(lap.H) is KronDecomposed:
+        P = lap.H.to_matrix().clone()
+    else:
+        P = lap.H.clone()
+    loss, n_data = deepcopy(lap.loss), deepcopy(lap.n_data)
+    # fit a second and third time but don't override
+    lap.fit(reg_loader, override=False)
+    lap.fit(reg_loader, override=False)
+    # Hessian should be now roughly 3x the one before
+    assert torch.allclose(3 * loss, lap.loss)
+    assert (3 * n_data) == lap.n_data
+    if type(lap.H) is KronDecomposed:
+        assert torch.allclose(lap.H.to_matrix(), 3 * P)
+    else:
+        assert torch.allclose(lap.H, 3 * P)
+
+
+def test_log_prob_full(model, class_loader):
+    lap = FullLaplace(model, 'classification', prior_precision=0.7)
+    theta = torch.randn_like(parameters_to_vector(model.parameters()))
+    # posterior without fitting is just prior
+    posterior = Normal(loc=torch.zeros_like(theta), scale=sqrt(1/0.7))
+    assert torch.allclose(lap.log_prob(theta), posterior.log_prob(theta).sum())
+    lap.fit(class_loader)
+    posterior = MultivariateNormal(loc=lap.mean, precision_matrix=lap.posterior_precision)
+    assert torch.allclose(lap.log_prob(theta), posterior.log_prob(theta))
+
+    
+def test_log_prob_kron(model, class_loader):
+    lap = KronLaplace(model, 'classification', prior_precision=0.24)
+    theta = torch.randn_like(parameters_to_vector(model.parameters()))
+    posterior = Normal(loc=lap.mean, scale=sqrt(1/0.24))
+    assert torch.allclose(lap.log_prob(theta), posterior.log_prob(theta).sum())
+    lap.fit(class_loader)
+    print(type(lap.H), type(lap.H_facs), lap._H_factor)
+    posterior = MultivariateNormal(loc=lap.mean, precision_matrix=lap.posterior_precision.to_matrix())
+    assert torch.allclose(lap.log_prob(theta), posterior.log_prob(theta))
 
 
 @pytest.mark.parametrize('laplace', flavors)

--- a/tests/test_lllaplace.py
+++ b/tests/test_lllaplace.py
@@ -135,7 +135,7 @@ def test_laplace_init_precision(laplace, model):
 
 
 @pytest.mark.parametrize('laplace', flavors)
-def test_laplace_init_prior_mean_and_scatter(laplace, model):
+def test_laplace_init_prior_mean_and_scatter(laplace, model, class_loader):
     lap_scalar_mean = laplace(model, 'classification', last_layer_name='1',
                               prior_precision=1e-2, prior_mean=1.)
     assert torch.allclose(lap_scalar_mean.prior_mean, torch.tensor([1.]))
@@ -148,6 +148,11 @@ def test_laplace_init_prior_mean_and_scatter(laplace, model):
     lap_tensor_full_mean = laplace(model, 'classification', last_layer_name='1',
                                    prior_precision=1e-2, prior_mean=torch.ones(20*2+2))
     assert torch.allclose(lap_tensor_full_mean.prior_mean, torch.ones(20*2+2))
+
+    lap_scalar_mean.fit(class_loader)
+    lap_tensor_mean.fit(class_loader)
+    lap_tensor_scalar_mean.fit(class_loader)
+    lap_tensor_full_mean.fit(class_loader)
     expected = lap_scalar_mean.scatter
     assert expected.ndim == 0
     assert torch.allclose(lap_tensor_mean.scatter, expected)
@@ -243,7 +248,7 @@ def test_laplace_functionality(laplace, lh, model, reg_loader, class_loader):
     assert samples.shape == torch.Size([1000000, len(theta)])
     mu_comp = samples.mean(dim=0)
     mu_true = lap.mean
-    assert torch.allclose(mu_comp, mu_true, rtol=1)
+    assert torch.allclose(mu_comp, mu_true, atol=1e-2)
 
     # test functional variance
     if laplace == FullLLLaplace:

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -138,7 +138,7 @@ def test_bmm(small_model):
     # test J @ S^-1/2  (sampling)
     JS = kron_decomp.bmm(Js, exponent=-1/2)
     JSJ = torch.bmm(JS, Js.transpose(1,2))
-    l, Q = S_inv.symeig(eigenvectors=True)
+    l, Q = torch.linalg.eigh(S_inv, UPLO='U')
     JS_true = Js @ Q @ torch.diag(torch.sqrt(l)) @ Q.T
     JSJ_true = torch.bmm(JS_true, Js.transpose(1,2))
     assert torch.allclose(JS, JS_true)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,7 +19,7 @@ def test_diagonal_add_scalar():
 def test_symeig_custom():
     X = torch.randn(20, 100)
     M = X @ X.T
-    l1, W1 = torch.symeig(M, eigenvectors=True)
+    l1, W1 = torch.linalg.eigh(M, UPLO='U')
     l2, W2 = symeig(M)
     assert torch.allclose(l1, l2)
     assert torch.allclose(W1, W2)
@@ -28,7 +28,7 @@ def test_symeig_custom():
 def test_symeig_custom_low_rank():
     X = torch.randn(1000, 10)
     M = X @ X.T
-    l1, W1 = torch.symeig(M, eigenvectors=True)
+    l1, W1 = torch.linalg.eigh(M, UPLO='U')
     l2, W2 = symeig(M)
     # symeig should fail for low-rank
     assert not torch.all(l1 >= 0.0)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,4 @@
 import torch
-import numpy as np
 
 
 def get_psd_matrix(dim):


### PR DESCRIPTION
Changes:
- make `mean` a quantity that falls back to prior when not yet fit and is set on `.fit()` so that `.log_prob()` is correct
- add `log_prob(value)` to compute log density under LA for regularization. This falls back to prior before fitting the LA
- add `.fit(train_loader, override=True)` where `override` means to reset Hessian approximation while `override == False` leads to adding up curvature, e.g., for continual learning