### PR TITLE
Refactor to keep initialization of H for all-weights and last-layer separate

### DIFF
--- a/laplace/__init__.py
+++ b/laplace/__init__.py
@@ -7,13 +7,17 @@
 REGRESSION = 'regression'
 CLASSIFICATION = 'classification'
 
-from laplace.baselaplace import BaseLaplace, ParametricLaplace, FullLaplace, KronLaplace, DiagLaplace, LowRankLaplace
+from laplace.baselaplace import (
+    BaseLaplace, ParametricLaplace, FullLaplaceBase, KronLaplaceBase, DiagLaplaceBase,
+    ALLaplace, FullLaplace, KronLaplace, DiagLaplace, LowRankLaplace)
 from laplace.lllaplace import LLLaplace, FullLLLaplace, KronLLLaplace, DiagLLLaplace
 from laplace.laplace import Laplace
 from laplace.marglik_training import marglik_training
 
 __all__ = ['Laplace',  # direct access to all Laplace classes via unified interface
            'BaseLaplace', 'ParametricLaplace',  # base-class and its (first-level) subclasses
+           'FullLaplaceBase', 'KronLaplaceBase', 'DiagLaplaceBase',  # base-classes for different Hessian structures
+           'ALLaplace',  # base-class all-weights
            'FullLaplace', 'KronLaplace', 'DiagLaplace', 'LowRankLaplace',  # all-weights
            'LLLaplace',  # base-class last-layer
            'FullLLLaplace', 'KronLLLaplace', 'DiagLLLaplace',  # last-layer

--- a/laplace/curvature/__init__.py
+++ b/laplace/curvature/__init__.py
@@ -8,10 +8,10 @@ except ModuleNotFoundError:
     logging.info('Backpack not available.')
 
 try:
-    from laplace.curvature.asdl import AsdlGGN, AsdlEF, AsdlInterface
+    from laplace.curvature.asdl import AsdlHessian, AsdlGGN, AsdlEF, AsdlInterface
 except ModuleNotFoundError:
     logging.info('asdfghjkl backend not available.')
 
 __all__ = ['CurvatureInterface', 'GGNInterface', 'EFInterface',
            'BackPackInterface', 'BackPackGGN', 'BackPackEF',
-           'AsdlInterface', 'AsdlGGN', 'AsdlEF']
+           'AsdlInterface', 'AsdlHessian', 'AsdlGGN', 'AsdlEF']

--- a/laplace/curvature/asdl.py
+++ b/laplace/curvature/asdl.py
@@ -115,7 +115,7 @@ class AsdlInterface(CurvatureInterface):
         diag_ggn = curv.matrices_to_vector(None)
         return self.factor * loss, self.factor * diag_ggn
 
-    def kron(self, X, y, N, **wkwargs) -> [torch.Tensor, Kron]:
+    def kron(self, X, y, N, **wkwargs):
         with torch.no_grad():
             if self.last_layer:
                 f, X = self.model.forward_with_features(X)

--- a/tests/test_baselaplace.py
+++ b/tests/test_baselaplace.py
@@ -9,6 +9,7 @@ from torch.distributions.multivariate_normal import MultivariateNormal
 from torch.nn.utils import parameters_to_vector
 from torch.utils.data import DataLoader, TensorDataset
 from torch.distributions import Normal, Categorical
+from torchvision.models import wide_resnet50_2
 
 from laplace.laplace import FullLaplace, KronLaplace, DiagLaplace, LowRankLaplace
 from laplace.matrix import KronDecomposed
@@ -32,6 +33,12 @@ def model():
 
 
 @pytest.fixture
+def large_model():
+    model = wide_resnet50_2()
+    return model
+
+
+@pytest.fixture
 def class_loader():
     X = torch.randn(10, 3)
     y = torch.randint(2, (10,))
@@ -48,6 +55,11 @@ def reg_loader():
 @pytest.mark.parametrize('laplace', flavors)
 def test_laplace_init(laplace, model):
     lap = laplace(model, 'classification')
+
+
+@pytest.mark.xfail(strict=True)
+def test_laplace_large_init(laplace, large_model):
+    lap = FullLaplace(large_model, 'classification')
 
 
 @pytest.mark.parametrize('laplace', flavors)

--- a/tests/test_lllaplace.py
+++ b/tests/test_lllaplace.py
@@ -6,6 +6,7 @@ from torch import nn
 from torch.nn.utils import parameters_to_vector
 from torch.utils.data import DataLoader, TensorDataset
 from torch.distributions import Normal, Categorical
+from torchvision.models import wide_resnet50_2
 
 from laplace.lllaplace import LLLaplace, FullLLLaplace, KronLLLaplace, DiagLLLaplace
 from laplace.feature_extractor import FeatureExtractor
@@ -21,6 +22,12 @@ flavors = [FullLLLaplace, KronLLLaplace, DiagLLLaplace]
 def model():
     model = torch.nn.Sequential(nn.Linear(3, 20), nn.Linear(20, 2))
     setattr(model, 'output_size', 2)
+    return model
+
+
+@pytest.fixture
+def large_model():
+    model = wide_resnet50_2()
     return model
 
 
@@ -41,6 +48,11 @@ def reg_loader():
 @pytest.mark.parametrize('laplace', flavors)
 def test_laplace_init(laplace, model):
     lap = laplace(model, 'classification', last_layer_name='1')
+
+
+@pytest.mark.parametrize('laplace', flavors)
+def test_laplace_large_init(laplace, large_model):
+    lap = laplace(large_model, 'classification')
 
 
 @pytest.mark.parametrize('laplace', flavors)


### PR DESCRIPTION
Addresses bug resulting from #62, first reported [here](https://github.com/runame/laplace-experiments/pull/17) (note: links to PR discussion in private repository). For the last-layer LA flavors the Hessian approximation `H` was first initialized for all-weights, which leads to out-of-memory errors for larger models.

Changes:
- Add `ALLaplace`, a base-class for all all-weights flavors, i.e. what `LLLaplace` is to the last-layer flavors. Through this change we can keep the initialization of `H` for the all-weights flavors completely separate from the initialization for the last-layer flavors.
- Refactor the all-weights flavors to have base-classes for `hessian_structure` flavors `'full'`, `'kron'`, and `'diag'`, which are used by their all-weights and last-layer variations of the corresponding Hessian structure.
- Remove redundant code + minor fixes.
- Add tests of initialization with a Wide ResNet 50-2 model, to check if it fails for `FullLaplace` and works with all last-layer flavors.

I think this refactor requires careful review, to avoid introducing some different unintended behavior.