### PR TITLE
Keep initialization of H for all-weights and last-layer separate

### DIFF
--- a/laplace/curvature/__init__.py
+++ b/laplace/curvature/__init__.py
@@ -8,10 +8,10 @@ except ModuleNotFoundError:
     logging.info('Backpack not available.')
 
 try:
-    from laplace.curvature.asdl import AsdlGGN, AsdlEF, AsdlInterface
+    from laplace.curvature.asdl import AsdlHessian, AsdlGGN, AsdlEF, AsdlInterface
 except ModuleNotFoundError:
     logging.info('asdfghjkl backend not available.')
 
 __all__ = ['CurvatureInterface', 'GGNInterface', 'EFInterface',
            'BackPackInterface', 'BackPackGGN', 'BackPackEF',
-           'AsdlInterface', 'AsdlGGN', 'AsdlEF']
+           'AsdlInterface', 'AsdlGGN', 'AsdlEF', 'AsdlHessian']

--- a/laplace/curvature/asdl.py
+++ b/laplace/curvature/asdl.py
@@ -115,7 +115,7 @@ class AsdlInterface(CurvatureInterface):
         diag_ggn = curv.matrices_to_vector(None)
         return self.factor * loss, self.factor * diag_ggn
 
-    def kron(self, X, y, N, **wkwargs) -> [torch.Tensor, Kron]:
+    def kron(self, X, y, N, **wkwargs):
         with torch.no_grad():
             if self.last_layer:
                 f, X = self.model.forward_with_features(X)

--- a/laplace/lllaplace.py
+++ b/laplace/lllaplace.py
@@ -9,7 +9,7 @@ from laplace.matrix import Kron
 from laplace.curvature import BackPackGGN
 
 
-__all__ = ['FullLLLaplace', 'KronLLLaplace', 'DiagLLLaplace']
+__all__ = ['LLLaplace', 'FullLLLaplace', 'KronLLLaplace', 'DiagLLLaplace']
 
 
 class LLLaplace(ParametricLaplace):
@@ -60,12 +60,13 @@ class LLLaplace(ParametricLaplace):
     def __init__(self, model, likelihood, sigma_noise=1., prior_precision=1.,
                  prior_mean=0., temperature=1., backend=BackPackGGN, last_layer_name=None,
                  backend_kwargs=None):
+        self.H = None
         super().__init__(model, likelihood, sigma_noise=sigma_noise, prior_precision=1.,
                          prior_mean=0., temperature=temperature, backend=backend,
                          backend_kwargs=backend_kwargs)
         self.model = FeatureExtractor(deepcopy(model), last_layer_name=last_layer_name)
         if self.model.last_layer is None:
-            self.mean = prior_mean
+            self.mean = None
             self.n_params = None
             self.n_layers = None
             # ignore checks of prior mean setter temporarily, check on .fit()
@@ -76,7 +77,8 @@ class LLLaplace(ParametricLaplace):
             self.n_layers = len(list(self.model.last_layer.parameters()))
             self.prior_precision = prior_precision
             self.prior_mean = prior_mean
-            self.mean = self.prior_mean 
+            self.mean = self.prior_mean
+            self._init_H()
         self._backend_kwargs['last_layer'] = True
 
     def fit(self, train_loader, override=True):
@@ -106,9 +108,6 @@ class LLLaplace(ParametricLaplace):
             # here, check the already set prior precision again
             self.prior_precision = self._prior_precision
             self.prior_mean = self._prior_mean
-            self._init_H()
-
-        if override:
             self._init_H()
 
         super().fit(train_loader, override=override)
@@ -159,12 +158,6 @@ class FullLLLaplace(LLLaplace, FullLaplace):
     # key to map to correct subclass of BaseLaplace, (subset of weights, Hessian structure)
     _key = ('last_layer', 'full')
 
-    def __init__(self, model, likelihood, sigma_noise=1., prior_precision=1.,
-                 prior_mean=0., temperature=1., backend=BackPackGGN, last_layer_name=None,
-                 backend_kwargs=None):
-        super().__init__(model, likelihood, sigma_noise, prior_precision,
-                         prior_mean, temperature, backend, last_layer_name, backend_kwargs)
-
 
 class KronLLLaplace(LLLaplace, KronLaplace):
     """Last-layer Laplace approximation with Kronecker factored log likelihood Hessian approximation
@@ -200,9 +193,3 @@ class DiagLLLaplace(LLLaplace, DiagLaplace):
     """
     # key to map to correct subclass of BaseLaplace, (subset of weights, Hessian structure)
     _key = ('last_layer', 'diag')
-
-    def __init__(self, model, likelihood, sigma_noise=1., prior_precision=1.,
-                 prior_mean=0., temperature=1., backend=BackPackGGN, last_layer_name=None,
-                 backend_kwargs=None):
-        super().__init__(model, likelihood, sigma_noise, prior_precision,
-                         prior_mean, temperature, backend, last_layer_name, backend_kwargs)

--- a/laplace/lllaplace.py
+++ b/laplace/lllaplace.py
@@ -93,6 +93,9 @@ class LLLaplace(ParametricLaplace):
             whether to initialize H, loss, and n_data again; setting to False is useful for
             online learning settings to accumulate a sequential posterior approximation.
         """
+        if not override:
+            raise ValueError('Last-layer Laplace approximations do not support `override=False`.')
+
         self.model.eval()
 
         if self.model.last_layer is None:


### PR DESCRIPTION
This is an alternative to #71: it addresses a bug resulting from #62, first reported [here](https://github.com/runame/laplace-experiments/pull/17) (note: links to PR discussion in private repository). For the last-layer LA flavors the Hessian approximation `H` was first initialized for all-weights, which leads to out-of-memory errors for larger models.

The advantage of the previous fix is that it keeps the classes for all-weights and last-layer flavors more strictly separated, which might make it harder to introduce similar bugs in the future. However, many more classes are necessary. @AlexImmer and me agreed that this additional complexity is probably not worth it.

Changes:
- Add better tests for the initialization of all the Laplace classes, also with a large model (Wide ResNet 50-2), as suggested in #69.
- Fix the `H` initialization bug. The `posterior_precision` falls back to the prior before calling `fit()` for the first time for most cases. Exceptions: a last-layer flavor which doesn't get the `last_layer_name` passed as an argument and low-rank Laplace. For these two cases, `H` will be `None`. When trying to call `posterior_precision` in these cases, a descriptive error will be raised.
- Remove redundant code + minor fixes.