### PR TITLE
Fixes and features for SubnetLaplace

### DIFF
--- a/laplace/__init__.py
+++ b/laplace/__init__.py
@@ -9,7 +9,7 @@ CLASSIFICATION = 'classification'
 
 from laplace.baselaplace import BaseLaplace, ParametricLaplace, FullLaplace, KronLaplace, DiagLaplace, LowRankLaplace
 from laplace.lllaplace import LLLaplace, FullLLLaplace, KronLLLaplace, DiagLLLaplace
-from laplace.subnetlaplace import SubnetLaplace
+from laplace.subnetlaplace import SubnetLaplace, FullSubnetLaplace, DiagSubnetLaplace
 from laplace.laplace import Laplace
 from laplace.marglik_training import marglik_training
 
@@ -18,5 +18,6 @@ __all__ = ['Laplace',  # direct access to all Laplace classes via unified interf
            'FullLaplace', 'KronLaplace', 'DiagLaplace', 'LowRankLaplace',  # all-weights
            'LLLaplace',  # base-class last-layer
            'FullLLLaplace', 'KronLLLaplace', 'DiagLLLaplace',  # last-layer
-           'SubnetLaplace',  # subnetwork
+           'SubnetLaplace',  # base-class subnetwork
+           'FullSubnetLaplace', 'DiagSubnetLaplace',  # subnetwork
            'marglik_training']  # methods

--- a/laplace/curvature/asdl.py
+++ b/laplace/curvature/asdl.py
@@ -115,6 +115,8 @@ class AsdlInterface(CurvatureInterface):
         curv = fisher_for_cross_entropy(self._model, self._ggn_type, SHAPE_DIAG,
                                         inputs=X, targets=y)
         diag_ggn = curv.matrices_to_vector(None)
+        if self.subnetwork_indices is not None:
+            diag_ggn = diag_ggn[self.subnetwork_indices]
         return self.factor * loss, self.factor * diag_ggn
 
     def kron(self, X, y, N, **wkwargs):

--- a/laplace/curvature/backpack.py
+++ b/laplace/curvature/backpack.py
@@ -123,6 +123,8 @@ class BackPackGGN(BackPackInterface, GGNInterface):
         with backpack(context()):
             loss.backward()
         dggn = self._get_diag_ggn()
+        if self.subnetwork_indices is not None:
+            dggn = dggn[self.subnetwork_indices]
 
         return self.factor * loss.detach(), self.factor * dggn
 
@@ -149,6 +151,8 @@ class BackPackEF(BackPackInterface, EFInterface):
             loss.backward()
         diag_EF = torch.cat([p.sum_grad_squared.data.flatten()
                              for p in self._model.parameters()])
+        if self.subnetwork_indices is not None:
+            diag_EF = diag_EF[self.subnetwork_indices]
 
         return self.factor * loss.detach(), self.factor * diag_EF
 

--- a/laplace/laplace.py
+++ b/laplace/laplace.py
@@ -20,8 +20,8 @@ def Laplace(model, likelihood, subset_of_weights='last_layer', hessian_structure
     laplace : ParametricLaplace
         chosen subclass of ParametricLaplace instantiated with additional arguments
     """
-    if subset_of_weights == 'subnetwork' and hessian_structure != 'full':
-        raise ValueError('Subnetwork Laplace requires using a full Hessian approximation!')
+    if subset_of_weights == 'subnetwork' and hessian_structure not in ['full', 'diag']:
+        raise ValueError('Subnetwork Laplace requires a full or diagonal Hessian approximation!')
 
     laplace_map = {subclass._key: subclass for subclass in _all_subclasses(ParametricLaplace)
                    if hasattr(subclass, '_key')}

--- a/laplace/subnetlaplace.py
+++ b/laplace/subnetlaplace.py
@@ -159,6 +159,15 @@ class DiagSubnetLaplace(SubnetLaplace, DiagLaplace):
     def _init_H(self):
         self.H = torch.zeros(self.n_params_subnet, device=self._device)
 
+    def _check_jacobians(self, Js):
+        if not isinstance(Js, torch.Tensor):
+            raise ValueError('Jacobians have to be torch.Tensor.')
+        if not Js.device == self._device:
+            raise ValueError('Jacobians need to be on the same device as Laplace.')
+        m, k, p = Js.size()
+        if p != self.n_params_subnet:
+            raise ValueError('Invalid Jacobians shape for Laplace posterior approx.')
+
     def sample(self, n_samples=100):
         # sample only subnetwork parameters and set all other parameters to their MAP estimates
         samples = torch.randn(n_samples, self.n_params_subnet, device=self._device)

--- a/laplace/subnetlaplace.py
+++ b/laplace/subnetlaplace.py
@@ -91,7 +91,8 @@ class SubnetLaplace(FullLaplace):
         """
         if subnetwork_indices is None:
             raise ValueError('Subnetwork indices cannot be None.')
-        elif not (isinstance(subnetwork_indices, torch.LongTensor) and
+        elif not ((isinstance(subnetwork_indices, torch.LongTensor) or
+            isinstance(subnetwork_indices, torch.cuda.LongTensor)) and
             subnetwork_indices.numel() > 0 and len(subnetwork_indices.shape) == 1):
             raise ValueError('Subnetwork indices must be non-empty 1-dimensional torch.LongTensor.')
         elif not (len(subnetwork_indices[subnetwork_indices < 0]) == 0 and

--- a/laplace/subnetlaplace.py
+++ b/laplace/subnetlaplace.py
@@ -118,6 +118,15 @@ class SubnetLaplace(FullLaplace):
 
         else:
             raise ValueError('Mismatch of prior and model. Diagonal or scalar prior.')
+    
+    @property
+    def mean_subnet(self):
+        return self.mean[self.backend.subnetwork_indices]
+
+    @property
+    def scatter(self):
+        delta = (self.mean_subnet - self.prior_mean)
+        return (delta * self.prior_precision_diag) @ delta
 
     def sample(self, n_samples=100):
         # sample parameters just of the subnetwork

--- a/laplace/subnetlaplace.py
+++ b/laplace/subnetlaplace.py
@@ -1,18 +1,17 @@
 import torch
 from torch.distributions import MultivariateNormal
 
-from laplace.baselaplace import FullLaplace
+from laplace.baselaplace import ParametricLaplace, FullLaplace, DiagLaplace
 from laplace.curvature import BackPackGGN
 
 
-__all__ = ['SubnetLaplace']
+__all__ = ['SubnetLaplace', 'FullSubnetLaplace', 'DiagSubnetLaplace']
 
 
-class SubnetLaplace(FullLaplace):
-    """Class for subnetwork Laplace, which computes the Laplace approximation over
-    just a subset of the model parameters (i.e. a subnetwork within the neural network),
-    as proposed in [1]. Subnetwork Laplace only supports a full Hessian approximation; other
-    approximations could be used in theory, but would not make as much sense conceptually.
+class SubnetLaplace(ParametricLaplace):
+    """Class for subnetwork Laplace, which computes the Laplace approximation over just a subset
+    of the model parameters (i.e. a subnetwork within the neural network), as proposed in [1].
+    Subnetwork Laplace can only be used with either a full or a diagonal Hessian approximation.
 
     A Laplace approximation is represented by a MAP which is given by the
     `model` parameter and a posterior precision or covariance specifying
@@ -67,9 +66,6 @@ class SubnetLaplace(FullLaplace):
         arguments passed to the backend on initialization, for example to
         set the number of MC samples for stochastic approximations.
     """
-    # key to map to correct subclass of BaseLaplace, (subset of weights, Hessian structure)
-    _key = ('subnetwork', 'full')
-
     def __init__(self, model, likelihood, subnetwork_indices, sigma_noise=1., prior_precision=1.,
                  prior_mean=0., temperature=1., backend=BackPackGGN, backend_kwargs=None):
         self.H = None
@@ -82,9 +78,6 @@ class SubnetLaplace(FullLaplace):
         self.n_params_subnet = len(subnetwork_indices)
         self._init_H()
 
-    def _init_H(self):
-        self.H = torch.zeros(self.n_params_subnet, self.n_params_subnet, device=self._device)
-
     def _check_subnetwork_indices(self, subnetwork_indices):
         """Check that subnetwork indices are valid indices of the vectorized model parameters
            (i.e. `torch.nn.utils.parameters_to_vector(model.parameters())`).
@@ -92,8 +85,8 @@ class SubnetLaplace(FullLaplace):
         if subnetwork_indices is None:
             raise ValueError('Subnetwork indices cannot be None.')
         elif not ((isinstance(subnetwork_indices, torch.LongTensor) or
-            isinstance(subnetwork_indices, torch.cuda.LongTensor)) and
-            subnetwork_indices.numel() > 0 and len(subnetwork_indices.shape) == 1):
+                   isinstance(subnetwork_indices, torch.cuda.LongTensor)) and
+                   subnetwork_indices.numel() > 0 and len(subnetwork_indices.shape) == 1):
             raise ValueError('Subnetwork indices must be non-empty 1-dimensional torch.LongTensor.')
         elif not (len(subnetwork_indices[subnetwork_indices < 0]) == 0 and
             len(subnetwork_indices[subnetwork_indices >= self.n_params]) == 0):
@@ -128,13 +121,47 @@ class SubnetLaplace(FullLaplace):
         delta = (self.mean_subnet - self.prior_mean)
         return (delta * self.prior_precision_diag) @ delta
 
-    def sample(self, n_samples=100):
-        # sample parameters just of the subnetwork
-        subnet_mean = self.mean[self.backend.subnetwork_indices]
-        dist = MultivariateNormal(loc=subnet_mean, scale_tril=self.posterior_scale)
-        subnet_samples = dist.sample((n_samples,))
-
-        # set all other parameters to their MAP estimates
-        full_samples = self.mean.repeat(n_samples, 1)
+    def assemble_full_samples(self, subnet_samples):
+        full_samples = self.mean.repeat(subnet_samples.shape[0], 1)
         full_samples[:, self.backend.subnetwork_indices] = subnet_samples
         return full_samples
+
+
+class FullSubnetLaplace(SubnetLaplace, FullLaplace):
+    """Subnetwork Laplace approximation with full, i.e., dense, log likelihood Hessian
+    approximation and hence posterior precision. Based on the chosen `backend` parameter,
+    the full approximation can be, for example, a generalized Gauss-Newton matrix.
+    Mathematically, we have \\(P \\in \\mathbb{R}^{P \\times P}\\).
+    See `FullLaplace`, `SubnetLaplace`, and `BaseLaplace` for the full interface.
+    """
+    # key to map to correct subclass of BaseLaplace, (subset of weights, Hessian structure)
+    _key = ('subnetwork', 'full')
+
+    def _init_H(self):
+        self.H = torch.zeros(self.n_params_subnet, self.n_params_subnet, device=self._device)
+
+    def sample(self, n_samples=100):
+        # sample only subnetwork parameters and set all other parameters to their MAP estimates
+        dist = MultivariateNormal(loc=self.mean_subnet, scale_tril=self.posterior_scale)
+        subnet_samples = dist.sample((n_samples,))
+        return self.assemble_full_samples(subnet_samples)
+
+
+class DiagSubnetLaplace(SubnetLaplace, DiagLaplace):
+    """Subnetwork Laplace approximation with diagonal log likelihood Hessian approximation
+    and hence posterior precision.
+    Mathematically, we have \\(P \\approx \\textrm{diag}(P)\\).
+    See `DiagLaplace`, `SubnetLaplace`, and `BaseLaplace` for the full interface.
+    """
+    # key to map to correct subclass of BaseLaplace, (subset of weights, Hessian structure)
+    _key = ('subnetwork', 'diag')
+
+    def _init_H(self):
+        self.H = torch.zeros(self.n_params_subnet, device=self._device)
+
+    def sample(self, n_samples=100):
+        # sample only subnetwork parameters and set all other parameters to their MAP estimates
+        samples = torch.randn(n_samples, self.n_params_subnet, device=self._device)
+        samples = samples * self.posterior_scale.reshape(1, self.n_params_subnet)
+        subnet_samples = self.mean_subnet.reshape(1, self.n_params_subnet) + samples
+        return self.assemble_full_samples(subnet_samples)


### PR DESCRIPTION
This PR aims to address #86. Namely, this implements the following changes:
- It fixes an issue where the subnet indices validity check would fail on GPU as we only allowed `torch.LongTensors` but not `torch.cuda.LongTensors`.
- It technically enables marginal likelihood computation and therefore optimization with `SubnetLaplace` (i.e. essentially makes sure that there are no dimension errors when calling `la.log_marginal_likelihood()` on a `SubnetLaplace` model); however we should generally not recommend using this, as the marginal likelihood is probably not meaningful when computed over a subnetwork (without any additional care that would likely require original research); so I'm not sure whether we should have this feature if we don't know how it'll behave.
- It adds `DiagSubnetLaplace`, a subclass of `SubnetLaplace` that uses a diagonal Hessian approximation (the existing full Hessian variant is now called `FullSubnetLaplace`); we initially thought that this wouldn't be useful as a full diagonal LA would probably be better in most cases and not incur much overhead, but this feature was explicitly requested in #86, so why not.

Let me know what you think!