### PR TITLE
Improve predictive samples

### DIFF
--- a/laplace/baselaplace.py
+++ b/laplace/baselaplace.py
@@ -4,7 +4,8 @@ import torch
 from torch.nn.utils import parameters_to_vector, vector_to_parameters
 from torch.distributions import MultivariateNormal, Dirichlet, Normal
 
-from laplace.utils import parameters_per_layer, invsqrt_precision, get_nll, validate, Kron
+from laplace.utils import (parameters_per_layer, invsqrt_precision, 
+                           get_nll, validate, Kron, normal_samples)
 from laplace.curvature import BackPackGGN, AsdlHessian
 
 
@@ -492,8 +493,9 @@ class ParametricLaplace(BaseLaplace):
 
         return self.log_likelihood - 0.5 * (self.log_det_ratio + self.scatter)
 
-    def __call__(self, x, pred_type='glm', link_approx='probit', n_samples=100):
-        """Compute the posterior predictive on input data `X`.
+    def __call__(self, x, pred_type='glm', link_approx='probit', n_samples=100, 
+                 diagonal_output=False, generator=None):
+        """Compute the posterior predictive on input data `x`.
 
         Parameters
         ----------
@@ -507,10 +509,17 @@ class ParametricLaplace(BaseLaplace):
 
         link_approx : {'mc', 'probit', 'bridge'}
             how to approximate the classification link function for the `'glm'`.
-            For `pred_type='nn'`, only 'mc' is possible.
+            For `pred_type='nn'`, only 'mc' is possible. 
 
         n_samples : int
             number of samples for `link_approx='mc'`.
+
+        diagonal_output : bool
+            whether to use a diagonalized posterior predictive on the outputs.
+            Only works for `pred_type='glm'` and `link_approx='mc'`.
+
+        generator : torch.Generator, optional
+            random number generator to control the samples (if sampling used)
 
         Returns
         -------
@@ -525,6 +534,10 @@ class ParametricLaplace(BaseLaplace):
 
         if link_approx not in ['mc', 'probit', 'bridge']:
             raise ValueError(f'Unsupported link approximation {link_approx}.')
+        
+        if generator is not None:
+            if type(generator) is not torch.Generator or generator.device != x.device:
+                raise ValueError('Invalid random generator (check type and device).')
 
         if pred_type == 'glm':
             f_mu, f_var = self._glm_predictive_distribution(x)
@@ -533,11 +546,8 @@ class ParametricLaplace(BaseLaplace):
                 return f_mu, f_var
             # classification
             if link_approx == 'mc':
-                try:
-                    dist = MultivariateNormal(f_mu, f_var)
-                except:
-                    dist = Normal(f_mu, torch.diagonal(f_var, dim1=1, dim2=2).sqrt())
-                return torch.softmax(dist.sample((n_samples,)), dim=-1).mean(dim=0)
+                return self.predictive_samples(x, pred_type='glm', n_samples=n_samples, 
+                                               diagonal_output=diagonal_output).mean(dim=0)
             elif link_approx == 'probit':
                 kappa = 1 / torch.sqrt(1. + np.pi / 8 * f_var.diagonal(dim1=1, dim2=2))
                 return torch.softmax(kappa * f_mu, dim=-1)
@@ -554,7 +564,8 @@ class ParametricLaplace(BaseLaplace):
                 return samples.mean(dim=0), samples.var(dim=0)
             return samples.mean(dim=0)
 
-    def predictive_samples(self, x, pred_type='glm', n_samples=100):
+    def predictive_samples(self, x, pred_type='glm', n_samples=100, 
+                           diagonal_output=False, generator=None):
         """Sample from the posterior predictive on input data `x`.
         Can be used, for example, for Thompson sampling.
 
@@ -571,6 +582,13 @@ class ParametricLaplace(BaseLaplace):
         n_samples : int
             number of samples
 
+        diagonal_output : bool
+            whether to use a diagonalized glm posterior predictive on the outputs.
+            Only applies when `pred_type='glm'`.
+
+        generator : torch.Generator, optional
+            random number generator to control the samples (if sampling used)
+
         Returns
         -------
         samples : torch.Tensor
@@ -582,11 +600,12 @@ class ParametricLaplace(BaseLaplace):
         if pred_type == 'glm':
             f_mu, f_var = self._glm_predictive_distribution(x)
             assert f_var.shape == torch.Size([f_mu.shape[0], f_mu.shape[1], f_mu.shape[1]])
-            dist = MultivariateNormal(f_mu, f_var)
-            samples = dist.sample((n_samples,))
+            if diagonal_output:
+                f_var = torch.diagonal(f_var, dim1=1, dim2=2)
+            f_samples = normal_samples(f_mu, f_var, n_samples, generator)
             if self.likelihood == 'regression':
-                return samples
-            return torch.softmax(samples, dim=-1)
+                return f_samples
+            return torch.softmax(f_samples, dim=-1)
 
         else:  # 'nn'
             return self._nn_predictive_samples(x, n_samples)

--- a/laplace/baselaplace.py
+++ b/laplace/baselaplace.py
@@ -536,7 +536,7 @@ class ParametricLaplace(BaseLaplace):
             raise ValueError(f'Unsupported link approximation {link_approx}.')
         
         if generator is not None:
-            if type(generator) is not torch.Generator or generator.device != x.device:
+            if not isinstance(generator, torch.Generator) or generator.device != x.device:
                 raise ValueError('Invalid random generator (check type and device).')
 
         if pred_type == 'glm':

--- a/laplace/utils/__init__.py
+++ b/laplace/utils/__init__.py
@@ -1,4 +1,4 @@
-from laplace.utils.utils import get_nll, validate, parameters_per_layer, invsqrt_precision, _is_batchnorm, _is_valid_scalar, kron, diagonal_add_scalar, symeig, block_diag, expand_prior_precision
+from laplace.utils.utils import get_nll, validate, parameters_per_layer, invsqrt_precision, _is_batchnorm, _is_valid_scalar, kron, diagonal_add_scalar, symeig, block_diag, expand_prior_precision, normal_samples
 from laplace.utils.feature_extractor import FeatureExtractor
 from laplace.utils.matrix import Kron, KronDecomposed
 from laplace.utils.swag import fit_diagonal_swag_var

--- a/laplace/utils/utils.py
+++ b/laplace/utils/utils.py
@@ -241,11 +241,11 @@ def normal_samples(mean, var, n_samples, generator=None):
     if mean.shape == var.shape:
         # diagonal covariance
         scaled_samples = var.sqrt().unsqueeze(-1) * randn_samples.unsqueeze(0)
-        return (mean.unsqueeze(-1) + scaled_samples).permute([2, 0, 1])
+        return (mean.unsqueeze(-1) + scaled_samples).permute((2, 0, 1))
     elif mean.shape == var.shape[:2] and var.shape[-1] == mean.shape[1]:
         # full covariance
         scale = torch.linalg.cholesky(var)
         scaled_samples = torch.matmul(scale, randn_samples.unsqueeze(0))  # expand batch dim
-        return (mean.unsqueeze(-1) + scaled_samples).permute([2, 0, 1])
+        return (mean.unsqueeze(-1) + scaled_samples).permute((2, 0, 1))
     else:
         raise ValueError('Invalid input shapes.')

--- a/laplace/utils/utils.py
+++ b/laplace/utils/utils.py
@@ -218,3 +218,34 @@ def expand_prior_precision(prior_prec, model):
     else:
         return torch.cat([delta * torch.ones_like(m).flatten() for delta, m
                           in zip(prior_prec, model.parameters())])
+
+
+def normal_samples(mean, var, n_samples, generator=None):
+    """Produce samples from a batch of Normal distributions either parameterized
+    by a diagonal or full covariance given by `var`.
+
+    Parameters
+    ----------
+    mean : torch.Tensor
+        `(batch_size, output_dim)`
+    var : torch.Tensor
+        (co)variance of the Normal distribution
+        `(batch_size, output_dim, output_dim)` or `(batch_size, output_dim)`
+    generator : torch.Generator
+        random number generator
+    """
+    assert mean.ndim == 2, 'Invalid input shape of mean, should be 2-dimensional.'
+    _, output_dim = mean.shape
+    randn_samples = torch.randn((output_dim, n_samples), device=mean.device, generator=generator)
+    
+    if mean.shape == var.shape:
+        # diagonal covariance
+        scaled_samples = var.sqrt().unsqueeze(-1) * randn_samples.unsqueeze(0)
+        return (mean.unsqueeze(-1) + scaled_samples).permute([2, 0, 1])
+    elif mean.shape == var.shape[:2] and var.shape[-1] == mean.shape[1]:
+        # full covariance
+        scale = torch.linalg.cholesky(var)
+        scaled_samples = torch.matmul(scale, randn_samples.unsqueeze(0))  # expand batch dim
+        return (mean.unsqueeze(-1) + scaled_samples).permute([2, 0, 1])
+    else:
+        raise ValueError('Invalid input shapes.')


### PR DESCRIPTION
Addresses #93 and #91 with following changes:
- add function to sample normal using broadcasting (#91) which leads to smoother predictives
- allow controlling randomness by passing `torch.Generator` (#91)
- diagonalize posterior predictive on output level only when asked for explicitly (#93)