### PR TITLE
Use ASDL as the default for classification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Data
+data/

--- a/laplace/lllaplace.py
+++ b/laplace/lllaplace.py
@@ -4,7 +4,6 @@ from torch.nn.utils import parameters_to_vector, vector_to_parameters
 
 from laplace.baselaplace import ParametricLaplace, FullLaplace, KronLaplace, DiagLaplace
 from laplace.utils import FeatureExtractor, Kron
-from laplace.curvature import BackPackGGN
 
 
 __all__ = ['LLLaplace', 'FullLLLaplace', 'KronLLLaplace', 'DiagLLLaplace']
@@ -56,7 +55,7 @@ class LLLaplace(ParametricLaplace):
         set the number of MC samples for stochastic approximations.
     """
     def __init__(self, model, likelihood, sigma_noise=1., prior_precision=1.,
-                 prior_mean=0., temperature=1., backend=BackPackGGN, last_layer_name=None,
+                 prior_mean=0., temperature=1., backend=None, last_layer_name=None,
                  backend_kwargs=None):
         self.H = None
         super().__init__(model, likelihood, sigma_noise=sigma_noise, prior_precision=1.,
@@ -176,7 +175,7 @@ class KronLLLaplace(LLLaplace, KronLaplace):
     _key = ('last_layer', 'kron')
 
     def __init__(self, model, likelihood, sigma_noise=1., prior_precision=1.,
-                 prior_mean=0., temperature=1., backend=BackPackGGN, last_layer_name=None,
+                 prior_mean=0., temperature=1., backend=None, last_layer_name=None,
                  damping=False, **backend_kwargs):
         self.damping = damping
         super().__init__(model, likelihood, sigma_noise, prior_precision,

--- a/laplace/subnetlaplace.py
+++ b/laplace/subnetlaplace.py
@@ -2,7 +2,6 @@ import torch
 from torch.distributions import MultivariateNormal
 
 from laplace.baselaplace import ParametricLaplace, FullLaplace, DiagLaplace
-from laplace.curvature import BackPackGGN
 
 
 __all__ = ['SubnetLaplace', 'FullSubnetLaplace', 'DiagSubnetLaplace']
@@ -67,7 +66,7 @@ class SubnetLaplace(ParametricLaplace):
         set the number of MC samples for stochastic approximations.
     """
     def __init__(self, model, likelihood, subnetwork_indices, sigma_noise=1., prior_precision=1.,
-                 prior_mean=0., temperature=1., backend=BackPackGGN, backend_kwargs=None):
+                 prior_mean=0., temperature=1., backend=None, backend_kwargs=None):
         self.H = None
         super().__init__(model, likelihood, sigma_noise=sigma_noise,
                          prior_precision=prior_precision, prior_mean=prior_mean,


### PR DESCRIPTION
This PR addresses #94 by simply setting `backend=None` as the default `Laplace` constructor argument and then determining the backend to use at runtime depending on the likelihood, i.e.
```python3
if backend is None:
    backend = AsdlGGN if likelihood == 'classification' else BackPackGGN
```

Let me know what you think!