### PR TITLE
Update Laplace bridge predictive

### DIFF
--- a/laplace/utils/utils.py
+++ b/laplace/utils/utils.py
@@ -236,7 +236,8 @@ def normal_samples(mean, var, n_samples, generator=None):
     """
     assert mean.ndim == 2, 'Invalid input shape of mean, should be 2-dimensional.'
     _, output_dim = mean.shape
-    randn_samples = torch.randn((output_dim, n_samples), device=mean.device, generator=generator)
+    randn_samples = torch.randn((output_dim, n_samples), device=mean.device, 
+                                dtype=mean.dtype, generator=generator)
     
     if mean.shape == var.shape:
         # diagonal covariance

--- a/tests/test_baselaplace.py
+++ b/tests/test_baselaplace.py
@@ -361,7 +361,7 @@ def test_regression_predictive(laplace, model, reg_loader):
     assert len(f_mu) == len(X)
 
     # NN predictive (only diagonal variance estimation)
-    f_mu, f_var = lap(X, pred_type='nn')
+    f_mu, f_var = lap(X, pred_type='nn', link_approx='mc')
     assert f_mu.shape == f_var.shape
     assert f_var.shape == torch.Size([f_mu.shape[0], f_mu.shape[1]])
     assert len(f_mu) == len(X)
@@ -388,10 +388,12 @@ def test_classification_predictive(laplace, model, class_loader):
     f_pred = lap(X, pred_type='glm', link_approx='bridge')
     assert f_pred.shape == f.shape
     assert torch.allclose(f_pred.sum(), torch.tensor(len(f_pred), dtype=torch.double))  # sum up to 1
-
+    f_pred = lap(X, pred_type='glm', link_approx='bridge_norm')
+    assert f_pred.shape == f.shape
+    assert torch.allclose(f_pred.sum(), torch.tensor(len(f_pred), dtype=torch.double))  # sum up to 1
 
     # NN predictive
-    f_pred = lap(X, pred_type='nn', n_samples=100)
+    f_pred = lap(X, pred_type='nn', link_approx='mc', n_samples=100)
     assert f_pred.shape == f.shape
     assert torch.allclose(f_pred.sum(), torch.tensor(len(f_pred), dtype=torch.double))  # sum up to 1
 
@@ -433,6 +435,6 @@ def test_classification_predictive_samples(laplace, model, class_loader):
     assert np.allclose(fsamples.sum().item(), len(f) * 100)  # sum up to 1
 
     # NN predictive
-    f_pred = lap.predictive_samples(X, pred_type='nn', n_samples=100)
+    fsamples = lap.predictive_samples(X, pred_type='nn', n_samples=100)
     assert fsamples.shape == torch.Size([100, f.shape[0], f.shape[1]])
     assert np.allclose(fsamples.sum().item(), len(f) * 100)  # sum up to 1

--- a/tests/test_lllaplace.py
+++ b/tests/test_lllaplace.py
@@ -334,7 +334,7 @@ def test_regression_predictive(laplace, model, reg_loader):
     assert len(f_mu) == len(X)
 
     # NN predictive (only diagonal variance estimation)
-    f_mu, f_var = lap(X, pred_type='nn')
+    f_mu, f_var = lap(X, pred_type='nn', link_approx='mc')
     assert f_mu.shape == f_var.shape
     assert f_var.shape == torch.Size([f_mu.shape[0], f_mu.shape[1]])
     assert len(f_mu) == len(X)
@@ -361,9 +361,12 @@ def test_classification_predictive(laplace, model, class_loader):
     f_pred = lap(X, pred_type='glm', link_approx='bridge')
     assert f_pred.shape == f.shape
     assert torch.allclose(f_pred.sum(), torch.tensor(len(f_pred), dtype=torch.double))  # sum up to 1
+    f_pred = lap(X, pred_type='glm', link_approx='bridge_norm')
+    assert f_pred.shape == f.shape
+    assert torch.allclose(f_pred.sum(), torch.tensor(len(f_pred), dtype=torch.double))  # sum up to 1
 
     # NN predictive
-    f_pred = lap(X, pred_type='nn', n_samples=100)
+    f_pred = lap(X, pred_type='nn', link_approx='mc', n_samples=100)
     assert f_pred.shape == f.shape
     assert torch.allclose(f_pred.sum(), torch.tensor(len(f_pred), dtype=torch.double))  # sum up to 1
 
@@ -405,6 +408,6 @@ def test_classification_predictive_samples(laplace, model, class_loader):
     assert np.allclose(fsamples.sum().item(), len(f) * 100)  # sum up to 1
 
     # NN predictive
-    f_pred = lap.predictive_samples(X, pred_type='nn', n_samples=100)
+    fsamples = lap.predictive_samples(X, pred_type='nn', n_samples=100)
     assert fsamples.shape == torch.Size([100, f.shape[0], f.shape[1]])
     assert np.allclose(fsamples.sum().item(), len(f) * 100)  # sum up to 1

--- a/tests/test_subnetlaplace.py
+++ b/tests/test_subnetlaplace.py
@@ -518,7 +518,7 @@ def test_regression_predictive(model, reg_loader, subnetwork_mask, hessian_struc
     assert len(f_mu) == len(X)
 
     # NN predictive (only diagonal variance estimation)
-    f_mu, f_var = lap(X, pred_type='nn')
+    f_mu, f_var = lap(X, pred_type='nn', link_approx='mc')
     assert f_mu.shape == f_var.shape
     assert f_var.shape == torch.Size([f_mu.shape[0], f_mu.shape[1]])
     assert len(f_mu) == len(X)
@@ -563,9 +563,12 @@ def test_classification_predictive(model, class_loader, subnetwork_mask, hessian
     f_pred = lap(X, pred_type='glm', link_approx='bridge')
     assert f_pred.shape == f.shape
     assert torch.allclose(f_pred.sum(), torch.tensor(len(f_pred), dtype=torch.double))  # sum up to 1
+    f_pred = lap(X, pred_type='glm', link_approx='bridge_norm')
+    assert f_pred.shape == f.shape
+    assert torch.allclose(f_pred.sum(), torch.tensor(len(f_pred), dtype=torch.double))  # sum up to 1
 
     # NN predictive
-    f_pred = lap(X, pred_type='nn', n_samples=100)
+    f_pred = lap(X, pred_type='nn', link_approx='mc', n_samples=100)
     assert f_pred.shape == f.shape
     assert torch.allclose(f_pred.sum(), torch.tensor(len(f_pred), dtype=torch.double))  # sum up to 1
 


### PR DESCRIPTION
Adjust LA bridge predictive to latest version of the paper. Thanks to @mariushobbhahn for the code blueprint.

I have also added a check to make sure people don't think they are using any other link approximation than `'mc'` together with `pred_type='nn'`.