### PR TITLE
Fix device and dtype of `block_diag` used for `Kron.to_matrix()`

### DIFF
--- a/laplace/utils/utils.py
+++ b/laplace/utils/utils.py
@@ -184,7 +184,7 @@ def block_diag(blocks):
     M : torch.Tensor
     """
     P = sum([b.shape[0] for b in blocks])
-    M = torch.zeros(P, P)
+    M = torch.zeros(P, P, dtype=blocks[0].dtype, device=blocks[0].device)
     p_cur = 0
     for block in blocks:
         p_block = block.shape[0]


### PR DESCRIPTION
Before this fix calling `to_matrix()` on an instance of the `Kron` class did not preserve the dtype and device, so even when everything is computed on GPU the returned matrix used to be on CPU, which is unexpected behavior.