### PR TITLE
Enable BayesOpt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,5 @@ dmypy.json
 
 # Data
 data/
+
+.DS_Store

--- a/examples/bayesopt_example.py
+++ b/examples/bayesopt_example.py
@@ -1,0 +1,313 @@
+import warnings
+warnings.filterwarnings('ignore')
+
+import numpy as np
+import functorch as ft
+import torch
+from torch import nn, optim
+from torch import distributions as dists
+from torch.nn import functional as F
+from gpytorch import distributions as gdists
+import torch.utils.data as data_utils
+from botorch.models.model import Model
+from botorch.posteriors.gpytorch import GPyTorchPosterior 
+import tqdm
+
+from laplace import Laplace
+from laplace.curvature import AsdlGGN, BackPackGGN, AsdlHessian
+
+import argparse, sys
+
+from botorch.models.gp_regression import SingleTaskGP
+from botorch.test_functions import Ackley, Branin
+from botorch.acquisition.analytic import ExpectedImprovement, UpperConfidenceBound
+from botorch.acquisition.monte_carlo import qExpectedImprovement
+from botorch.optim.optimize import optimize_acqf
+
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Hashable,
+    List,
+    Mapping,
+    Optional,
+    TYPE_CHECKING,
+    TypeVar,
+    Union,
+)
+
+
+class LaplaceBNN(Model):
+    """
+    Install first:
+    pip install laplace-torch
+    """
+
+    def __init__(
+            self,
+            train_X: torch.Tensor,
+            train_Y: torch.Tensor,
+            bnn: Laplace = None,
+            likelihood: str = 'regression',
+            batch_size: int = 1024):
+
+        super().__init__()
+
+        self.train_X = train_X
+        self.train_Y = train_Y
+        self.likelihood = likelihood
+        self.batch_size = batch_size
+        self.nn = nn.Sequential(
+            nn.Linear(train_X.shape[-1], 50),
+            nn.ReLU(),
+            nn.Linear(50, 50),
+            nn.Tanh(),
+            nn.Linear(50, train_Y.shape[-1])
+        )
+        self.bnn = bnn
+
+        if self.bnn is None:
+            self._train_model(self._get_train_loader())
+
+
+    def posterior(
+        self,
+        X: torch.Tensor,
+        output_indices: Optional[List[int]] = None,
+        observation_noise: bool = False,
+        posterior_transform=None,
+        **kwargs: Any,
+    ) -> GPyTorchPosterior:
+        """
+        Note: q is the num. of x's predicted jointly
+        """
+        # Transform to `(batch_shape*q, d)`
+        B, Q, D = X.shape
+        X = X.reshape(B*Q, D)
+
+        # Posterior predictive distribution
+        # mean_y is (batch_shape*q, k); cov_y is (batch_shape*q*k, batch_shape*q*k)
+        mean_y, cov_y = self._get_prediction(X, joint=True)
+
+        # Mean in `(batch_shape, q*k)`
+        K = self.num_outputs
+        mean_y = mean_y.reshape(B, Q*K)
+
+        # Cov is `(batch_shape, q*k, q*k)`
+        cov_y += 1e-4*torch.eye(B*Q*K)
+        cov_y = cov_y.reshape(B, Q, K, B, Q, K)
+        cov_y = torch.einsum('bqkbrl->bqkrl', cov_y)  # (B, Q, K, Q, K)
+        cov_y = cov_y.reshape(B, Q*K, Q*K)
+
+        dist = gdists.MultivariateNormal(mean_y, covariance_matrix=cov_y)
+        post_pred = GPyTorchPosterior(dist)
+
+        if posterior_transform is not None:
+            return posterior_transform(post_pred)
+
+        return post_pred
+
+
+    def condition_on_observations(self, X: torch.Tensor, Y: torch.Tensor, **kwargs: Any) -> Model:
+        self.train_X = torch.cat([self.train_X, X], dim=0)
+        self.train_Y = torch.cat([self.train_Y, Y], dim=0)
+
+        train_loader = self._get_train_loader()
+        self._train_model(train_loader)
+
+        return LaplaceBNN(
+            # Added dataset & retrained BNN
+            self.train_X, self.train_Y, self.bnn,
+            self.likelihood, self.batch_size
+        )
+
+    @property
+    def num_outputs(self) -> int:
+        r"""The number of outputs of the model."""
+        return self.train_Y.shape[-1]
+
+    def _train_model(self, train_loader):
+        """
+        Train BNN with the Laplace approximation
+        """
+        n_epochs = 1000
+        optimizer = optim.Adam(self.nn.parameters(), lr=1e-1, weight_decay=1e-3)
+        scheduler = optim.lr_scheduler.CosineAnnealingLR(optimizer, n_epochs*len(train_loader))
+        loss_func = nn.MSELoss()
+
+        for i in range(n_epochs):
+            for x, y in train_loader:
+                optimizer.zero_grad()
+                output = self.nn(x)
+                loss = loss_func(output, y)
+                loss.backward()
+                optimizer.step()
+                scheduler.step()
+
+        self.nn.eval()
+
+        self.bnn = Laplace(
+            self.nn, self.likelihood,
+            subset_of_weights='all', hessian_structure='kron',
+        )
+        self.bnn.fit(train_loader)
+        self.bnn.optimize_prior_precision(n_steps=30)
+
+
+    def _get_prediction(self, test_x: torch.Tensor, joint=True, use_test_loader=False):
+        """
+        Batched Laplace prediction.
+
+        Args:
+            test_x: Tensor of size `(batch_shape, d)`.
+
+        Returns:
+            Tensor of size `(batch_shape, k)`
+        """
+        if self.bnn is None:
+            print('Train your model first before making prediction!')
+
+        if not use_test_loader:
+            mean_y, cov_y = self.bnn(test_x, joint=joint)
+        else:
+            test_loader = data_utils.DataLoader(
+                data_utils.TensorDataset(test_x, torch.zeros_like(test_x)),
+                batch_size=256
+            )
+
+            mean_y, cov_y = [], []
+
+            for x_batch, _ in test_loader:
+                _mean_y, _cov_y = self.bnn(x_batch, joint=joint)
+                mean_y.append(_mean_y)
+                cov_y.append(_cov_y)
+
+            mean_y = torch.cat(mean_y, dim=0).squeeze()
+            cov_y = torch.cat(cov_y, dim=0).squeeze()
+
+        return mean_y, cov_y
+
+
+    def _get_train_loader(self):
+        return data_utils.DataLoader(
+            data_utils.TensorDataset(self.train_X, self.train_Y),
+            batch_size=self.batch_size, shuffle=True
+        )
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--test_func', choices=['ackley', 'branin'], default='branin')
+    parser.add_argument('--acqf', choices=['EI', 'UCB', 'qEI'], default='EI')
+    parser.add_argument('--init_data', type=int, default=20)
+    parser.add_argument('--exp_len', type=int, default=500)
+    parser.add_argument('--randseed', type=int, default=1)
+    args = parser.parse_args()
+
+    np.random.seed(args.randseed)
+    torch.set_default_dtype(torch.float64)
+    torch.manual_seed(args.randseed)
+
+    if args.test_func == 'ackley':
+        true_f = Ackley(dim=2)
+        bounds = torch.tensor([[-32.768, 32.768], [-32.768, 32.768]]).T.double()
+    elif args.test_func == 'branin':
+        true_f = Branin()
+        bounds = torch.tensor([[-5, 10], [0, 15]]).T.double()
+    else:
+        print('Invalid test function!')
+        sys.exit(1)
+
+    print()
+    print(f'Test Function: {args.test_func}')
+    print('-------------------------------------')
+    print()
+
+    train_data_points = 20
+
+    train_x = torch.cat([
+        dists.Uniform(*bounds.T[i]).sample((train_data_points, 1))
+        for i in range(2)  # for each dimension
+    ], dim=1)
+    train_y = true_f(train_x).reshape(-1, 1)
+
+    test_x = torch.cat([
+        dists.Uniform(*bounds.T[i]).sample((10000, 1))
+        for i in range(2)  # for each dimension
+    ], dim=1) 
+    test_y = true_f(test_x)
+
+    models = {
+        'RandomSearch': None, 
+        'BNN-LA': LaplaceBNN(train_x, train_y),
+        'GP': SingleTaskGP(train_x, train_y),
+    }
+
+
+    def evaluate_model(model_name, model):
+        if model_name == 'GP':
+            pred = model.posterior(test_x).mean.squeeze()
+        elif model_name == 'BNN-LA':
+            pred, _ = model._get_prediction(test_x, use_test_loader=True, joint=False)
+        else:
+            return -1
+
+        return F.mse_loss(pred, test_y).squeeze().item()
+
+
+    for model_name, model in models.items():
+        np.random.seed(args.randseed)
+        torch.set_default_dtype(torch.float64)
+        torch.manual_seed(args.randseed)
+
+        best_y = train_y.min().item()
+        trace_best_y = []
+        pbar = tqdm.trange(args.exp_len)
+        pbar.set_description(
+            f'[{model_name}, MSE = {evaluate_model(model_name, model):.3f}; Best f(x) = {best_y:.3f}]'
+        )
+
+        for i in pbar:
+            if model_name == 'RandomSearch':
+                new_x = torch.cat([
+                    dists.Uniform(*bounds.T[i]).sample((1, 1))
+                    for i in range(len(bounds))  # for each dimension
+                ], dim=1).squeeze()
+            else:
+                if args.acqf == 'EI':
+                    acq_f = ExpectedImprovement(model, best_f=best_y, maximize=False)
+                elif args.acqf == 'UCB':
+                    acq_f = UpperConfidenceBound(model, beta=0.2, maximize=False)
+                elif args.acqf == 'qEI':
+                    acq_f = qExpectedImprovement(model, best_f=best_y, maximize=False)
+                else:
+                    print('Invalid acquisition function!')
+                    sys.exit(1)
+
+                # Get a proposal for new x
+                new_x, val = optimize_acqf(
+                    acq_f,
+                    bounds=bounds,
+                    q=1 if args.acqf not in ['qEI'] else 5,
+                    num_restarts=10,
+                    raw_samples=20
+                )
+
+            if len(new_x.shape) == 1:
+                new_x = new_x.unsqueeze(0)
+            
+            # Evaluate the objective on the proposed x
+            new_y = true_f(new_x).unsqueeze(-1)  # (q, 1)
+
+            # Update posterior
+            if model_name != 'RandomSearch':
+                model = model.condition_on_observations(new_x, new_y)
+
+            # Update the current best y
+            if new_y.min().item() <= best_y:
+                best_y = new_y.min().item()
+
+            trace_best_y.append(best_y)
+            pbar.set_description(
+                f'[{model_name}, MSE = {evaluate_model(model_name, model):.3f}; Best f(x) = {best_y:.3f}, curr f(x) = {new_y.min().item():.3f}]'
+            )

--- a/examples/regression_example.py
+++ b/examples/regression_example.py
@@ -47,9 +47,22 @@ print(f'sigma={la.sigma_noise.item():.2f}',
       f'prior precision={la.prior_precision.item():.2f}')
 
 x = X_test.flatten().cpu().numpy()
-f_mu, f_var = la(X_test)
+
+# Two options:
+# 1.) Marginal predictive distribution N(f_map(x_i), var(x_i))
+# The mean is (m,k), the var is (m,k,k)
+f_mu, f_var = la(X_test)  
+
+# 2.) Joint pred. dist. N((f_map(x_1),...,f_map(x_m)), Cov(f(x_1),...,f(x_m)))
+# The mean is (m*k,) where k is the output dim. The cov is (m*k,m*k)
+f_mu_joint, f_cov = la(X_test, joint=True)  
+
+# Both should be true
+print(torch.allclose(f_mu.flatten(), f_mu_joint))
+print(torch.allclose(f_var.flatten(), f_cov.diag()))
+
 f_mu = f_mu.squeeze().detach().cpu().numpy()
-f_sigma = f_var.squeeze().sqrt().cpu().numpy()
+f_sigma = f_var.squeeze().detach().sqrt().cpu().numpy()
 pred_std = np.sqrt(f_sigma**2 + la.sigma_noise.item()**2)
 
 plot_regression(X_train, y_train, x, f_mu, pred_std, 

--- a/examples/regression_example.py
+++ b/examples/regression_example.py
@@ -58,8 +58,8 @@ f_mu, f_var = la(X_test)
 f_mu_joint, f_cov = la(X_test, joint=True)  
 
 # Both should be true
-print(torch.allclose(f_mu.flatten(), f_mu_joint))
-print(torch.allclose(f_var.flatten(), f_cov.diag()))
+assert torch.allclose(f_mu.flatten(), f_mu_joint)
+assert torch.allclose(f_var.flatten(), f_cov.diag())
 
 f_mu = f_mu.squeeze().detach().cpu().numpy()
 f_sigma = f_var.squeeze().detach().sqrt().cpu().numpy()

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,0 +1,4 @@
+botorch==0.8.2
+gpytorch==1.9.1
+tqdm
+netcal==1.1.3

--- a/laplace/baselaplace.py
+++ b/laplace/baselaplace.py
@@ -363,7 +363,7 @@ class ParametricLaplace(BaseLaplace):
             self.n_data = 0
 
         self.model.eval()
-        self.mean = parameters_to_vector(self.model.parameters()).detach()
+        self.mean = parameters_to_vector(self.model.parameters())
 
         X, _ = next(iter(train_loader))
         with torch.no_grad():
@@ -631,7 +631,7 @@ class ParametricLaplace(BaseLaplace):
     def _glm_predictive_distribution(self, X):
         Js, f_mu = self.backend.jacobians(X)
         f_var = self.functional_variance(Js)
-        return f_mu.detach(), f_var.detach()
+        return f_mu, f_var
 
     def _nn_predictive_samples(self, X, n_samples=100):
         fs = list()

--- a/laplace/baselaplace.py
+++ b/laplace/baselaplace.py
@@ -538,7 +538,7 @@ class ParametricLaplace(BaseLaplace):
             Only works for `pred_type='glm'` and `link_approx='mc'`.
 
         generator : torch.Generator, optional
-            random number generator to control the samples (if sampling used)=
+            random number generator to control the samples (if sampling used).
 
         Returns
         -------

--- a/laplace/baselaplace.py
+++ b/laplace/baselaplace.py
@@ -923,8 +923,8 @@ class KronLaplace(ParametricLaplace):
     def functional_covariance(self, Js):
         self._check_jacobians(Js)
         n_batch, n_outs, n_params = Js.shape
-        Js = Js.reshape(1, n_batch*n_outs, n_params)
-        cov = self.posterior_precision.inv_square_form(Js).squeeze()
+        Js = Js.reshape(n_batch*n_outs, n_params).unsqueeze(0)
+        cov = self.posterior_precision.inv_square_form(Js).squeeze(0)
         assert cov.shape == (n_batch*n_outs, n_batch*n_outs)
         return cov
 

--- a/laplace/curvature/asdl.py
+++ b/laplace/curvature/asdl.py
@@ -18,7 +18,7 @@ class AsdlInterface(CurvatureInterface):
     """Interface for asdfghjkl backend.
     """
 
-    def jacobians(self, x):
+    def jacobians(self, x, enable_backprop=False):
         """Compute Jacobians \\(\\nabla_\\theta f(x;\\theta)\\) at current parameter \\(\\theta\\)
         using asdfghjkl's gradient per output dimension.
 
@@ -26,6 +26,8 @@ class AsdlInterface(CurvatureInterface):
         ----------
         x : torch.Tensor
             input data `(batch, input_shape)` on compatible device with model.
+        enable_backprop : bool, default = False
+            whether to enable backprop through the Js and f w.r.t. x
 
         Returns
         -------

--- a/laplace/curvature/asdl.py
+++ b/laplace/curvature/asdl.py
@@ -63,7 +63,7 @@ class AsdlInterface(CurvatureInterface):
         Gs : torch.Tensor
             gradients `(batch, parameters)`
         """
-        f = batch_gradient(self.model, self.lossfunc, x, y)
+        f = batch_gradient(self.model, self.lossfunc, x, y).detach()
         Gs = _get_batch_grad(self._model)
         if self.subnetwork_indices is not None:
             Gs = Gs[:, self.subnetwork_indices]

--- a/laplace/curvature/asdl.py
+++ b/laplace/curvature/asdl.py
@@ -63,7 +63,7 @@ class AsdlInterface(CurvatureInterface):
         Gs : torch.Tensor
             gradients `(batch, parameters)`
         """
-        f = batch_gradient(self.model, self.lossfunc, x, y).detach()
+        f = batch_gradient(self.model, self.lossfunc, x, y)
         Gs = _get_batch_grad(self._model)
         if self.subnetwork_indices is not None:
             Gs = Gs[:, self.subnetwork_indices]

--- a/laplace/curvature/backpack.py
+++ b/laplace/curvature/backpack.py
@@ -24,7 +24,6 @@ class BackPackInterface(CurvatureInterface):
         ----------
         x : torch.Tensor
             input data `(batch, input_shape)` on compatible device with model.
-
         enable_backprop : bool, default = False
             whether to enable backprop through the Js and f w.r.t. x
 

--- a/laplace/curvature/backpack.py
+++ b/laplace/curvature/backpack.py
@@ -16,7 +16,7 @@ class BackPackInterface(CurvatureInterface):
         extend(self._model)
         extend(self.lossfunc)
 
-    def jacobians(self, x):
+    def jacobians(self, x, enable_backprop=False):
         """Compute Jacobians \\(\\nabla_{\\theta} f(x;\\theta)\\) at current parameter \\(\\theta\\)
         using backpack's BatchGrad per output dimension.
 
@@ -24,6 +24,9 @@ class BackPackInterface(CurvatureInterface):
         ----------
         x : torch.Tensor
             input data `(batch, input_shape)` on compatible device with model.
+
+        enable_backprop : bool, default = False
+            whether to enable backprop through the Js and f w.r.t. x
 
         Returns
         -------
@@ -39,12 +42,18 @@ class BackPackInterface(CurvatureInterface):
             out = model(x)
             with backpack(BatchGrad()):
                 if model.output_size > 1:
-                    out[:, i].sum().backward()
+                    out[:, i].sum().backward(
+                        create_graph=enable_backprop, 
+                        retain_graph=enable_backprop
+                    )
                 else:
-                    out.sum().backward(retain_graph=True)
+                    out.sum().backward(
+                        create_graph=enable_backprop, 
+                        retain_graph=enable_backprop
+                    )
                 to_cat = []
                 for param in model.parameters():
-                    to_cat.append(param.grad_batch.detach().reshape(x.shape[0], -1))
+                    to_cat.append(param.grad_batch.reshape(x.shape[0], -1))
                     delattr(param, 'grad_batch')
                 Jk = torch.cat(to_cat, dim=1)
                 if self.subnetwork_indices is not None:

--- a/laplace/curvature/backpack.py
+++ b/laplace/curvature/backpack.py
@@ -41,7 +41,7 @@ class BackPackInterface(CurvatureInterface):
                 if model.output_size > 1:
                     out[:, i].sum().backward()
                 else:
-                    out.sum().backward()
+                    out.sum().backward(retain_graph=True)
                 to_cat = []
                 for param in model.parameters():
                     to_cat.append(param.grad_batch.detach().reshape(x.shape[0], -1))
@@ -51,7 +51,7 @@ class BackPackInterface(CurvatureInterface):
                     Jk = Jk[:, self.subnetwork_indices]
             to_stack.append(Jk)
             if i == 0:
-                f = out.detach()
+                f = out
 
         model.zero_grad()
         CTX.remove_hooks()

--- a/laplace/curvature/curvature.py
+++ b/laplace/curvature/curvature.py
@@ -87,7 +87,7 @@ class CurvatureInterface:
         if self.model.last_layer.bias is not None:
             Js = torch.cat([Js, identity], dim=2)
 
-        return Js, f.detach()
+        return Js, f
 
     def gradients(self, x, y):
         """Compute gradients \\(\\nabla_\\theta \\ell(f(x;\\theta, y)\\) at current parameter \\(\\theta\\).

--- a/laplace/curvature/curvature.py
+++ b/laplace/curvature/curvature.py
@@ -44,13 +44,15 @@ class CurvatureInterface:
     def _model(self):
         return self.model.last_layer if self.last_layer else self.model
 
-    def jacobians(self, x):
+    def jacobians(self, x, enable_backprop=False):
         """Compute Jacobians \\(\\nabla_\\theta f(x;\\theta)\\) at current parameter \\(\\theta\\).
 
         Parameters
         ----------
         x : torch.Tensor
             input data `(batch, input_shape)` on compatible device with model.
+        enable_backprop : bool, default = False
+            whether to enable backprop through the Js and f w.r.t. x
 
         Returns
         -------
@@ -61,13 +63,14 @@ class CurvatureInterface:
         """
         raise NotImplementedError
 
-    def last_layer_jacobians(self, x):
+    def last_layer_jacobians(self, x, enable_backprop=False):
         """Compute Jacobians \\(\\nabla_{\\theta_\\textrm{last}} f(x;\\theta_\\textrm{last})\\) 
         only at current last-layer parameter \\(\\theta_{\\textrm{last}}\\).
 
         Parameters
         ----------
         x : torch.Tensor
+        enable_backprop : bool, default=False
 
         Returns
         -------

--- a/laplace/lllaplace.py
+++ b/laplace/lllaplace.py
@@ -192,7 +192,7 @@ class KronLLLaplace(LLLaplace, KronLaplace):
     _key = ('last_layer', 'kron')
 
     def __init__(self, model, likelihood, sigma_noise=1., prior_precision=1.,
-                 prior_mean=0., temperature=1., enable_backprop=True, backend=None, last_layer_name=None,
+                 prior_mean=0., temperature=1., enable_backprop=False, backend=None, last_layer_name=None,
                  damping=False, **backend_kwargs):
         self.damping = damping
         super().__init__(model, likelihood, sigma_noise, prior_precision,

--- a/laplace/lllaplace.py
+++ b/laplace/lllaplace.py
@@ -116,7 +116,7 @@ class LLLaplace(ParametricLaplace):
     def _glm_predictive_distribution(self, X):
         Js, f_mu = self.backend.last_layer_jacobians(X)
         f_var = self.functional_variance(Js)
-        return f_mu.detach(), f_var.detach()
+        return f_mu, f_var
 
     def _nn_predictive_samples(self, X, n_samples=100):
         fs = list()

--- a/laplace/lllaplace.py
+++ b/laplace/lllaplace.py
@@ -46,6 +46,9 @@ class LLLaplace(ParametricLaplace):
     temperature : float, default=1
         temperature of the likelihood; lower temperature leads to more
         concentrated posterior and vice versa.
+    enable_backprop: bool, default=False
+        whether to enable backprop to the input `x` through the Laplace predictive.
+        Useful for e.g. Bayesian optimization.
     backend : subclasses of `laplace.curvature.CurvatureInterface`
         backend for access to curvature/Hessian approximations
     last_layer_name: str, default=None
@@ -55,13 +58,17 @@ class LLLaplace(ParametricLaplace):
         set the number of MC samples for stochastic approximations.
     """
     def __init__(self, model, likelihood, sigma_noise=1., prior_precision=1.,
-                 prior_mean=0., temperature=1., backend=None, last_layer_name=None,
+                 prior_mean=0., temperature=1., enable_backprop=False, backend=None, last_layer_name=None,
                  backend_kwargs=None):
         self.H = None
         super().__init__(model, likelihood, sigma_noise=sigma_noise, prior_precision=1.,
-                         prior_mean=0., temperature=temperature, backend=backend,
+                         prior_mean=0., temperature=temperature, 
+                         enable_backprop=enable_backprop, backend=backend,
                          backend_kwargs=backend_kwargs)
-        self.model = FeatureExtractor(deepcopy(model), last_layer_name=last_layer_name)
+        self.model = FeatureExtractor(
+            deepcopy(model), last_layer_name=last_layer_name,
+            enable_backprop=enable_backprop
+        )
         if self.model.last_layer is None:
             self.mean = None
             self.n_params = None
@@ -111,9 +118,12 @@ class LLLaplace(ParametricLaplace):
             self._init_H()
 
         super().fit(train_loader, override=override)
-        self.mean = parameters_to_vector(self.model.last_layer.parameters()).detach()
+        self.mean = parameters_to_vector(self.model.last_layer.parameters())
 
-    def _glm_predictive_distribution(self, X, joint=False, detach=True):
+        if not self.enable_backprop:
+            self.mean = self.mean.detach()
+
+    def _glm_predictive_distribution(self, X, joint=False):
         Js, f_mu = self.backend.last_layer_jacobians(X)
         
         if joint:
@@ -122,14 +132,14 @@ class LLLaplace(ParametricLaplace):
         else:
             f_var = self.functional_variance(Js)
 
-        return (f_mu.detach(), f_var.detach()) if detach else (f_mu, f_var)
+        return (f_mu.detach(), f_var.detach()) if not self.enable_backprop else (f_mu, f_var)
 
-    def _nn_predictive_samples(self, X, n_samples=100, detach=True):
+    def _nn_predictive_samples(self, X, n_samples=100):
         fs = list()
         for sample in self.sample(n_samples):
             vector_to_parameters(sample, self.model.last_layer.parameters())
             f = self.model(X.to(self._device))
-            fs.append(f.detach() if detach else f)
+            fs.append(f.detach() if not self.enable_backprop else f)
         vector_to_parameters(self.mean, self.model.last_layer.parameters())
         fs = torch.stack(fs)
         if self.likelihood == 'classification':
@@ -182,11 +192,11 @@ class KronLLLaplace(LLLaplace, KronLaplace):
     _key = ('last_layer', 'kron')
 
     def __init__(self, model, likelihood, sigma_noise=1., prior_precision=1.,
-                 prior_mean=0., temperature=1., backend=None, last_layer_name=None,
+                 prior_mean=0., temperature=1., enable_backprop=True, backend=None, last_layer_name=None,
                  damping=False, **backend_kwargs):
         self.damping = damping
         super().__init__(model, likelihood, sigma_noise, prior_precision,
-                         prior_mean, temperature, backend, last_layer_name, backend_kwargs)
+                         prior_mean, temperature, enable_backprop, backend, last_layer_name, backend_kwargs)
 
     def _init_H(self):
         self.H = Kron.init_from_model(self.model.last_layer, self._device)

--- a/laplace/marglik_training.py
+++ b/laplace/marglik_training.py
@@ -30,7 +30,8 @@ def marglik_training(
     marglik_frequency=1,
     prior_prec_init=1.,
     sigma_noise_init=1.,
-    temperature=1.
+    temperature=1.,
+    enable_backprop=False
 ):
     """Marginal-likelihood based training (Algorithm 1 in [1]). 
     Optimize model parameters and hyperparameters jointly.
@@ -103,6 +104,8 @@ def marglik_training(
         initial observation noise (for regression only)
     temperature : float, default=1.0
         factor for the likelihood for 'overcounting' data. Might be required for data augmentation.
+    enable_backprop : bool, default=False
+        make the returned Laplace instance backpropable---useful for e.g. Bayesian optimization.
 
     Returns
     -------
@@ -253,7 +256,7 @@ def marglik_training(
     lap = Laplace(
         model, likelihood, hessian_structure=hessian_structure, sigma_noise=sigma_noise, 
         prior_precision=prior_prec, temperature=temperature, backend=backend,
-        subset_of_weights='all'
+        subset_of_weights='all', enable_backprop=enable_backprop
     )
     lap.fit(train_loader)
     return lap, model, margliks, losses

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     backpack-for-pytorch
     asdfghjkl
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
-python_requires = >=3.8
+python_requires = >=3.7
 
 [options.packages.find]
 exclude = tests*

--- a/tests/test_curv_backends_backpack.py
+++ b/tests/test_curv_backends_backpack.py
@@ -250,24 +250,3 @@ def test_kron_normalization_class(class_Xy, model):
     loss_test, kron_test  = backend.kron(X, y, N=7)
     assert torch.allclose(kron_true.diag(), kron_test.diag())
     assert torch.allclose(loss_true, loss_test)
-
-
-def test_backprop_jacs(reg_Xy, model, model_singleoutput):
-    X, y = reg_Xy
-    X.requires_grad = True
-
-    for m in [model, model_singleoutput]:
-        backend = BackPackGGN(m, 'regression', stochastic=False)
-
-        try:
-            Js, f = backend.jacobians(X, enable_backprop=True)
-            grad_X_f = torch.autograd.grad(f.sum(), X)[0]
-
-            X.grad = None
-            Js, f = backend.jacobians(X, enable_backprop=True)
-            grad_X_Js = torch.autograd.grad(Js.sum(), X)[0]
-
-            assert grad_X_f.shape == X.shape
-            assert grad_X_Js.shape == X.shape
-        except RuntimeError:
-            assert False

--- a/tests/test_jacobians.py
+++ b/tests/test_jacobians.py
@@ -94,3 +94,79 @@ def test_last_layer_jacobians_multioutput(multioutput_model, X, backend_cls):
     assert torch.abs(Js-Js_naive).max() < 1e-6
     assert torch.allclose(model(X), f_naive)
     assert torch.allclose(f, f_naive)
+
+
+@pytest.mark.parametrize('backend_cls', [BackPackInterface])
+def test_backprop_jacobians_singleoutput(singleoutput_model, X, backend_cls):
+    X.requires_grad = True
+    backend = backend_cls(singleoutput_model, 'regression')
+
+    try:
+        Js, f = backend.jacobians(X, enable_backprop=True)
+        grad_X_f = torch.autograd.grad(f.sum(), X)[0]
+
+        X.grad = None
+        Js, f = backend.jacobians(X, enable_backprop=True)
+        grad_X_Js = torch.autograd.grad(Js.sum(), X)[0]
+
+        assert grad_X_f.shape == X.shape
+        assert grad_X_Js.shape == X.shape
+    except RuntimeError:
+        assert False
+
+
+@pytest.mark.parametrize('backend_cls', [BackPackInterface])
+def test_backprop_jacobians_multioutput(multioutput_model, X, backend_cls):
+    X.requires_grad = True
+    backend = backend_cls(multioutput_model, 'regression')
+
+    try:
+        Js, f = backend.jacobians(X, enable_backprop=True)
+        grad_X_f = torch.autograd.grad(f.sum(), X)[0]
+
+        X.grad = None
+        Js, f = backend.jacobians(X, enable_backprop=True)
+        grad_X_Js = torch.autograd.grad(Js.sum(), X)[0]
+
+        assert grad_X_f.shape == X.shape
+        assert grad_X_Js.shape == X.shape
+    except RuntimeError:
+        assert False
+
+
+@pytest.mark.parametrize('backend_cls', [BackPackInterface])
+def test_backprop_last_layer_jacobians_singleoutput(singleoutput_model, X, backend_cls):
+    X.requires_grad = True
+    backend = backend_cls(singleoutput_model, 'regression')
+
+    try:
+        Js, f = backend.last_layer_jacobians(X)
+        grad_X_f = torch.autograd.grad(f.sum(), X)[0]
+
+        X.grad = None
+        Js, f = backend.jacobians(X)
+        grad_X_Js = torch.autograd.grad(Js.sum(), X)[0]
+
+        assert grad_X_f.shape == X.shape
+        assert grad_X_Js.shape == X.shape
+    except RuntimeError:
+        assert False
+
+
+@pytest.mark.parametrize('backend_cls', [BackPackInterface])
+def test_backprop_last_layer_jacobians_multioutput(multioutput_model, X, backend_cls):
+    X.requires_grad = True
+    backend = backend_cls(multioutput_model, 'regression')
+
+    try:
+        Js, f = backend.last_layer_jacobians(X)
+        grad_X_f = torch.autograd.grad(f.sum(), X)[0]
+
+        X.grad = None
+        Js, f = backend.jacobians(X)
+        grad_X_Js = torch.autograd.grad(Js.sum(), X)[0]
+
+        assert grad_X_f.shape == X.shape
+        assert grad_X_Js.shape == X.shape
+    except RuntimeError:
+        assert False

--- a/tests/test_jacobians.py
+++ b/tests/test_jacobians.py
@@ -105,7 +105,6 @@ def test_backprop_jacobians_singleoutput(singleoutput_model, X, backend_cls):
         Js, f = backend.jacobians(X, enable_backprop=True)
         grad_X_f = torch.autograd.grad(f.sum(), X)[0]
 
-        X.grad = None
         Js, f = backend.jacobians(X, enable_backprop=True)
         grad_X_Js = torch.autograd.grad(Js.sum(), X)[0]
 
@@ -137,13 +136,14 @@ def test_backprop_jacobians_multioutput(multioutput_model, X, backend_cls):
 @pytest.mark.parametrize('backend_cls', [BackPackInterface])
 def test_backprop_last_layer_jacobians_singleoutput(singleoutput_model, X, backend_cls):
     X.requires_grad = True
-    backend = backend_cls(FeatureExtractor(singleoutput_model), 'regression')
+    backend = backend_cls(
+        FeatureExtractor(singleoutput_model, enable_backprop=True), 'regression'
+    )
 
     try:
         Js, f = backend.last_layer_jacobians(X)
         grad_X_f = torch.autograd.grad(f.sum(), X)[0]
 
-        X.grad = None
         Js, f = backend.last_layer_jacobians(X)
         grad_X_Js = torch.autograd.grad(Js.sum(), X)[0]
 
@@ -156,13 +156,14 @@ def test_backprop_last_layer_jacobians_singleoutput(singleoutput_model, X, backe
 @pytest.mark.parametrize('backend_cls', [BackPackInterface])
 def test_backprop_last_layer_jacobians_multioutput(multioutput_model, X, backend_cls):
     X.requires_grad = True
-    backend = backend_cls(FeatureExtractor(multioutput_model), 'regression')
+    backend = backend_cls(
+        FeatureExtractor(multioutput_model, enable_backprop=True), 'regression'
+    )
 
     try:
         Js, f = backend.last_layer_jacobians(X)
         grad_X_f = torch.autograd.grad(f.sum(), X)[0]
 
-        X.grad = None
         Js, f = backend.last_layer_jacobians(X)
         grad_X_Js = torch.autograd.grad(Js.sum(), X)[0]
 

--- a/tests/test_jacobians.py
+++ b/tests/test_jacobians.py
@@ -137,14 +137,14 @@ def test_backprop_jacobians_multioutput(multioutput_model, X, backend_cls):
 @pytest.mark.parametrize('backend_cls', [BackPackInterface])
 def test_backprop_last_layer_jacobians_singleoutput(singleoutput_model, X, backend_cls):
     X.requires_grad = True
-    backend = backend_cls(singleoutput_model, 'regression')
+    backend = backend_cls(FeatureExtractor(singleoutput_model), 'regression')
 
     try:
         Js, f = backend.last_layer_jacobians(X)
         grad_X_f = torch.autograd.grad(f.sum(), X)[0]
 
         X.grad = None
-        Js, f = backend.jacobians(X)
+        Js, f = backend.last_layer_jacobians(X)
         grad_X_Js = torch.autograd.grad(Js.sum(), X)[0]
 
         assert grad_X_f.shape == X.shape
@@ -156,14 +156,14 @@ def test_backprop_last_layer_jacobians_singleoutput(singleoutput_model, X, backe
 @pytest.mark.parametrize('backend_cls', [BackPackInterface])
 def test_backprop_last_layer_jacobians_multioutput(multioutput_model, X, backend_cls):
     X.requires_grad = True
-    backend = backend_cls(multioutput_model, 'regression')
+    backend = backend_cls(FeatureExtractor(multioutput_model), 'regression')
 
     try:
         Js, f = backend.last_layer_jacobians(X)
         grad_X_f = torch.autograd.grad(f.sum(), X)[0]
 
         X.grad = None
-        Js, f = backend.jacobians(X)
+        Js, f = backend.last_layer_jacobians(X)
         grad_X_Js = torch.autograd.grad(Js.sum(), X)[0]
 
         assert grad_X_f.shape == X.shape

--- a/tests/test_lllaplace.py
+++ b/tests/test_lllaplace.py
@@ -433,6 +433,25 @@ def test_backprop_glm(laplace, model, reg_loader):
 
 
 @pytest.mark.parametrize('laplace', flavors)
+def test_backprop_glm_joint(laplace, model, reg_loader):
+    X, y = reg_loader.dataset.tensors
+    X.requires_grad = True
+
+    lap = laplace(model, 'regression', enable_backprop=True)
+    lap.fit(reg_loader)
+    f_mu, f_cov = lap(X, pred_type='glm', joint=True)
+
+    try:
+        grad_X_mu = torch.autograd.grad(f_mu.sum(), X, retain_graph=True)[0]
+        grad_X_var = torch.autograd.grad(f_cov.sum(), X)[0] 
+
+        assert grad_X_mu.shape == X.shape
+        assert grad_X_var.shape == X.shape
+    except ValueError:
+        assert False
+
+
+@pytest.mark.parametrize('laplace', flavors)
 def test_backprop_glm_mc(laplace, model, reg_loader):
     X, y = reg_loader.dataset.tensors
     X.requires_grad = True

--- a/tests/test_lllaplace.py
+++ b/tests/test_lllaplace.py
@@ -411,3 +411,60 @@ def test_classification_predictive_samples(laplace, model, class_loader):
     fsamples = lap.predictive_samples(X, pred_type='nn', n_samples=100)
     assert fsamples.shape == torch.Size([100, f.shape[0], f.shape[1]])
     assert np.allclose(fsamples.sum().item(), len(f) * 100)  # sum up to 1
+
+
+@pytest.mark.parametrize('laplace', flavors)
+def test_backprop_glm(laplace, model, reg_loader):
+    X, y = reg_loader.dataset.tensors
+    X.requires_grad = True
+
+    lap = laplace(model, 'regression', enable_backprop=True)
+    lap.fit(reg_loader)
+    f_mu, f_var = lap(X, pred_type='glm')
+
+    try:
+        grad_X_mu = torch.autograd.grad(f_mu.sum(), X, retain_graph=True)[0]
+        grad_X_var = torch.autograd.grad(f_var.sum(), X)[0] 
+
+        assert grad_X_mu.shape == X.shape
+        assert grad_X_var.shape == X.shape
+    except ValueError:
+        assert False
+
+
+@pytest.mark.parametrize('laplace', flavors)
+def test_backprop_glm_mc(laplace, model, reg_loader):
+    X, y = reg_loader.dataset.tensors
+    X.requires_grad = True
+
+    lap = laplace(model, 'regression', enable_backprop=True)
+    lap.fit(reg_loader)
+    f_mu, f_var = lap(X, pred_type='glm', link_approx='mc')
+
+    try:
+        grad_X_mu = torch.autograd.grad(f_mu.sum(), X, retain_graph=True)[0]
+        grad_X_var = torch.autograd.grad(f_var.sum(), X)[0] 
+
+        assert grad_X_mu.shape == X.shape
+        assert grad_X_var.shape == X.shape
+    except ValueError:
+        assert False
+
+
+@pytest.mark.parametrize('laplace', flavors)
+def test_backprop_nn(laplace, model, reg_loader):
+    X, y = reg_loader.dataset.tensors
+    X.requires_grad = True
+
+    lap = laplace(model, 'regression', enable_backprop=True)
+    lap.fit(reg_loader)
+    f_mu, f_var = lap(X, pred_type='nn', link_approx='mc', n_samples=10)
+
+    try:
+        grad_X_mu = torch.autograd.grad(f_mu.sum(), X, retain_graph=True)[0]
+        grad_X_var = torch.autograd.grad(f_var.sum(), X)[0] 
+
+        assert grad_X_mu.shape == X.shape
+        assert grad_X_var.shape == X.shape
+    except ValueError:
+        assert False


### PR DESCRIPTION
Changes:

* Remove `detach()` in GLM predictive so that one can backprop from `f(x)` to `x`, in particular for optimizing acquisition functions.
* Add `functional_covariance` method for GLM predictive that returns the `(nk,)` mean and the `(nk, nk)` covariance over `n` input points and `k` outputs.
* Add example implementation of a linearized-Laplace-based BoTorch model for BayesOpt.