### PR TITLE
Add `prior_structure` argument to `optimize_prior_precision`

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ for a regression (MSELoss) loss function.
 In the following example, a pre-trained model is loaded,
 then the Laplace approximation is fit to the training data
 (using a diagonal Hessian approximation over all parameters),
-and the prior precision is optimized with cross-validation `'CV'`.
+and the prior precision is optimized with cross-validation `'gridsearch'`.
 After that, the resulting LA is used for prediction with
 the `'probit'` predictive for classification.
 
@@ -87,7 +87,7 @@ la = Laplace(model, 'classification',
              subset_of_weights='all',
              hessian_structure='diag')
 la.fit(train_loader)
-la.optimize_prior_precision(method='CV', val_loader=val_loader)
+la.optimize_prior_precision(method='gridsearch', val_loader=val_loader)
 
 # User-specified predictive approx.
 pred = la(x, link_approx='probit')

--- a/laplace/baselaplace.py
+++ b/laplace/baselaplace.py
@@ -210,7 +210,7 @@ class BaseLaplace:
             type of posterior predictive, linearized GLM predictive or neural
             network sampling predictive or Gaussian Process (GP) inference.
             The GLM predictive is consistent with the curvature approximations used here.
-        method : {'marglik', 'CV'}, default='marglik'
+        method : {'marglik', 'gridsearch'}, default='marglik'
             specifies how the prior precision should be optimized.
         n_steps : int, default=100
             the number of gradient descent steps to take.
@@ -224,16 +224,16 @@ class BaseLaplace:
         val_loader : torch.data.utils.DataLoader, default=None
             DataLoader for the validation set; each iterate is a training batch (X, y).
         loss : callable, default=get_nll
-            loss function to use for CV.
+            loss function to use for gridsearch.
         cv_loss_with_var: bool, default=False
             if true, `loss` takes three arguments `loss(output_mean, output_var, target)`,
             otherwise, `loss` takes two arguments `loss(output_mean, target)`
         log_prior_prec_min : float, default=-4
-            lower bound of gridsearch interval for CV.
+            lower bound of gridsearch interval.
         log_prior_prec_max : float, default=4
-            upper bound of gridsearch interval for CV.
+            upper bound of gridsearch interval.
         grid_size : int, default=100
-            number of values to consider inside the gridsearch interval for CV.
+            number of values to consider inside the gridsearch interval.
         link_approx : {'mc', 'probit', 'bridge'}, default='probit'
             how to approximate the classification link function for the `'glm'`.
             For `pred_type='nn'`, only `'mc'` is possible.
@@ -260,9 +260,9 @@ class BaseLaplace:
                 neg_log_marglik.backward()
                 optimizer.step()
             self.prior_precision = log_prior_prec.detach().exp()
-        elif method == 'CV':
+        elif method == 'gridsearch':
             if val_loader is None:
-                raise ValueError('CV requires a validation set DataLoader')
+                raise ValueError('gridsearch requires a validation set DataLoader')
             interval = torch.logspace(
                 log_prior_prec_min, log_prior_prec_max, grid_size
             )
@@ -271,7 +271,7 @@ class BaseLaplace:
                 link_approx=link_approx, n_samples=n_samples, loss_with_var=cv_loss_with_var
             )
         else:
-            raise ValueError('For now only marglik and CV is implemented.')
+            raise ValueError('For now only marglik and gridsearch is implemented.')
         if verbose:
             print(f'Optimized prior precision is {self.prior_precision}.')
 

--- a/laplace/baselaplace.py
+++ b/laplace/baselaplace.py
@@ -190,7 +190,7 @@ class BaseLaplace:
         n_steps=100,
         lr=1e-1,
         init_prior_prec=1.,
-        prior_structure='layerwise',
+        prior_structure='scalar',
         val_loader=None,
         loss=get_nll,
         log_prior_prec_min=-4,
@@ -218,7 +218,7 @@ class BaseLaplace:
             the learning rate to use for gradient descent.
         init_prior_prec : float or tensor, default=1.0
             initial prior precision before the first optimization step.
-        prior_structure : {'scalar', 'layerwise', 'diag'}, default='layerwise'
+        prior_structure : {'scalar', 'layerwise', 'diag'}, default='scalar'
             if init_prior_prec is scalar, the prior precision is optimized with this structure.
             otherwise, the structure of init_prior_prec is maintained.
         val_loader : torch.data.utils.DataLoader, default=None
@@ -700,7 +700,7 @@ class ParametricLaplace(BaseLaplace):
         raise NotImplementedError
 
     def optimize_prior_precision(self, method='marglik', pred_type='glm', n_steps=100, lr=1e-1,
-                                 init_prior_prec=1., prior_structure='layerwise', val_loader=None,
+                                 init_prior_prec=1., prior_structure='scalar', val_loader=None,
                                  loss=get_nll, log_prior_prec_min=-4, log_prior_prec_max=4,
                                  grid_size=100, link_approx='probit', n_samples=100, verbose=False,
                                  cv_loss_with_var=False):

--- a/laplace/marglik_training.py
+++ b/laplace/marglik_training.py
@@ -9,7 +9,7 @@ import logging
 
 from laplace import Laplace
 from laplace.curvature import AsdlGGN
-from laplace.utils import expand_prior_precision
+from laplace.utils import expand_prior_precision, fix_prior_prec_structure
 
 
 def marglik_training(
@@ -88,7 +88,7 @@ def marglik_training(
     lr_hyp : float, default=0.1
         Adam learning rate for hyperparameters
     prior_structure : str, default='layerwise'
-        structure of the prior. one of `['scalar', 'layerwise', 'diagonal']`
+        structure of the prior. one of `['scalar', 'layerwise', 'diag']`
     n_epochs_burnin : int default=0
         how many epochs to train without estimating and differentiating marglik
     n_hypersteps : int, default=10
@@ -129,14 +129,8 @@ def marglik_training(
     hyperparameters = list()
     # prior precision
     log_prior_prec_init = np.log(temperature * prior_prec_init)
-    if prior_structure == 'scalar':
-        log_prior_prec = log_prior_prec_init * torch.ones(1, device=device)
-    elif prior_structure == 'layerwise':
-        log_prior_prec = log_prior_prec_init * torch.ones(H, device=device)
-    elif prior_structure == 'diagonal':
-        log_prior_prec = log_prior_prec_init * torch.ones(P, device=device)
-    else:
-        raise ValueError(f'Invalid prior structure {prior_structure}')
+    log_prior_prec = fix_prior_prec_structure(
+        log_prior_prec_init, prior_structure, H, P, device)
     log_prior_prec.requires_grad = True
     hyperparameters.append(log_prior_prec)
 

--- a/laplace/utils/__init__.py
+++ b/laplace/utils/__init__.py
@@ -1,4 +1,4 @@
-from laplace.utils.utils import get_nll, validate, parameters_per_layer, invsqrt_precision, _is_batchnorm, _is_valid_scalar, kron, diagonal_add_scalar, symeig, block_diag, expand_prior_precision, normal_samples
+from laplace.utils.utils import get_nll, validate, parameters_per_layer, invsqrt_precision, _is_batchnorm, _is_valid_scalar, kron, diagonal_add_scalar, symeig, block_diag, expand_prior_precision, normal_samples, fix_prior_prec_structure
 from laplace.utils.feature_extractor import FeatureExtractor
 from laplace.utils.matrix import Kron, KronDecomposed
 from laplace.utils.swag import fit_diagonal_swag_var
@@ -6,7 +6,9 @@ from laplace.utils.subnetmask import SubnetMask, RandomSubnetMask, LargestMagnit
 
 
 __all__ = ['get_nll', 'validate', 'parameters_per_layer', 'invsqrt_precision', 'kron',
-		   'diagonal_add_scalar', 'symeig', 'block_diag', 'expand_prior_precision',
+		   'diagonal_add_scalar', 'symeig', 'block_diag', 'normal_samples',
+           '_is_batchnorm', '_is_valid_scalar',
+           'expand_prior_precision', 'fix_prior_prec_structure',
 		   'FeatureExtractor',
            'Kron', 'KronDecomposed',
 		   'fit_diagonal_swag_var',

--- a/laplace/utils/utils.py
+++ b/laplace/utils/utils.py
@@ -220,6 +220,18 @@ def expand_prior_precision(prior_prec, model):
                           in zip(prior_prec, model.parameters())])
 
 
+def fix_prior_prec_structure(prior_prec_init, prior_structure, n_layers, n_params, device):
+    if prior_structure == 'scalar':
+        prior_prec_init = torch.full((1,), prior_prec_init, device=device)   
+    elif prior_structure == 'layerwise':
+        prior_prec_init = torch.full((n_layers,), prior_prec_init, device=device)
+    elif prior_structure == 'diag':
+        prior_prec_init = torch.full((n_params,), prior_prec_init, device=device)
+    else:
+        raise ValueError(f'Invalid prior structure {prior_structure}.')
+    return prior_prec_init
+
+
 def normal_samples(mean, var, n_samples, generator=None):
     """Produce samples from a batch of Normal distributions either parameterized
     by a diagonal or full covariance given by `var`.


### PR DESCRIPTION
Changes:
- Add a helper function `fix_prior_prec_structure` for marglik optimization.
- Add `prior_structure` argument to `optimize_prior_precision`, such that we can easily optimize a layer-wise or diagonal prior precision post-hoc.
- Rename the method `CV` for `optimize_prior_precision` to `gridsearch`.