### PR TITLE
Replacing `torch.einsum()`  with `opt_einsum`

### DIFF
--- a/laplace/utils/matrix.py
+++ b/laplace/utils/matrix.py
@@ -2,6 +2,7 @@ from math import pow
 import torch
 import numpy as np
 from typing import Union
+import opt_einsum as oe 
 
 from laplace.utils import _is_valid_scalar, symeig, kron, block_diag
 
@@ -458,7 +459,7 @@ class KronDecomposed:
                     l = torch.pow(torch.outer(l1 + delta_sqrt, l2 + delta_sqrt), exponent)
                 else:
                     l = torch.pow(torch.outer(l1, l2) + delta, exponent)
-                d = torch.einsum('mp,nq,pq,mp,nq->mn', Q1, Q2, l, Q1, Q2).flatten()
+                d = oe.contract('mp,nq,pq,mp,nq->mn', Q1, Q2, l, Q1, Q2).flatten()
                 diags.append(d)
         return torch.cat(diags)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ install_requires =
     torchaudio
     backpack-for-pytorch
     asdfghjkl
+    opt_einsum
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
 python_requires = >=3.8
 


### PR DESCRIPTION
Changes: 
Previously, the torch.einsum() was causing memory issues, leading to out-of-memory errors during the call of diag function.
Replacing it with the equivalent opt_einsum implementation solved the issue and alleviated memory consumption during runtime.