### PR TITLE
Add support for cross entropy loss inputs with multiple leading dimensions

### DIFF
--- a/laplace/curvature/asdl.py
+++ b/laplace/curvature/asdl.py
@@ -1,4 +1,5 @@
 import warnings
+
 import numpy as np
 import torch
 
@@ -7,7 +8,6 @@ from asdl.matrices import (
 )
 from asdl.grad_maker import LOSS_MSE, LOSS_CROSS_ENTROPY
 from asdl.fisher import FisherConfig, get_fisher_maker
-# from asdl.fisher import calculate_fisher
 from asdl.hessian import HessianMaker, HessianConfig
 from asdl.gradient import batch_gradient
 
@@ -20,10 +20,8 @@ EPS = 1e-6
 class AsdlInterface(CurvatureInterface):
     """Interface for asdfghjkl backend.
     """
-    def __init__(self, model, likelihood, last_layer=False, subnetwork_indices=None,
-                 kfac_conv='kfac-expand'):
+    def __init__(self, model, likelihood, last_layer=False, subnetwork_indices=None):
         super().__init__(model, likelihood, last_layer, subnetwork_indices)
-        self.kfac_conv = kfac_conv
 
     @property
     def loss_type(self):
@@ -235,9 +233,8 @@ class AsdlHessian(AsdlInterface):
 class AsdlGGN(AsdlInterface, GGNInterface):
     """Implementation of the `GGNInterface` using asdfghjkl.
     """
-    def __init__(self, model, likelihood, last_layer=False, subnetwork_indices=None, stochastic=False,
-                 kfac_conv='kfac-expand'):
-        super().__init__(model, likelihood, last_layer, subnetwork_indices, kfac_conv=kfac_conv)
+    def __init__(self, model, likelihood, last_layer=False, subnetwork_indices=None, stochastic=False):
+        super().__init__(model, likelihood, last_layer, subnetwork_indices)
         self.stochastic = stochastic
 
     @property
@@ -248,8 +245,8 @@ class AsdlGGN(AsdlInterface, GGNInterface):
 class AsdlEF(AsdlInterface, EFInterface):
     """Implementation of the `EFInterface` using asdfghjkl.
     """
-    def __init__(self, model, likelihood, last_layer=False, kfac_conv='kfac-expand'):
-        super().__init__(model, likelihood, last_layer, kfac_conv=kfac_conv)
+    def __init__(self, model, likelihood, last_layer=False):
+        super().__init__(model, likelihood, last_layer)
 
     @property
     def _ggn_type(self):

--- a/laplace/curvature/backpack.py
+++ b/laplace/curvature/backpack.py
@@ -119,6 +119,9 @@ class BackPackGGN(BackPackInterface, GGNInterface):
     def diag(self, X, y, **kwargs):
         context = DiagGGNMC if self.stochastic else DiagGGNExact
         f = self.model(X)
+        # Assumes that the last dimension of f is of size outputs.
+        f = f if self.likelihood == 'regression' else f.view(-1, f.size(-1))
+        y = y if self.likelihood == 'regression' else y.view(-1)
         loss = self.lossfunc(f, y)
         with backpack(context()):
             loss.backward()
@@ -131,6 +134,9 @@ class BackPackGGN(BackPackInterface, GGNInterface):
     def kron(self, X, y, N, **kwargs) -> [torch.Tensor, Kron]:
         context = KFAC if self.stochastic else KFLR
         f = self.model(X)
+        # Assumes that the last dimension of f is of size outputs.
+        f = f if self.likelihood == 'regression' else f.view(-1, f.size(-1))
+        y = y if self.likelihood == 'regression' else y.view(-1)
         loss = self.lossfunc(f, y)
         with backpack(context()):
             loss.backward()
@@ -146,6 +152,9 @@ class BackPackEF(BackPackInterface, EFInterface):
 
     def diag(self, X, y, **kwargs):
         f = self.model(X)
+        # Assumes that the last dimension of f is of size outputs.
+        f = f if self.likelihood == 'regression' else f.view(-1, f.size(-1))
+        y = y if self.likelihood == 'regression' else y.view(-1)
         loss = self.lossfunc(f, y)
         with backpack(SumGradSquared()):
             loss.backward()

--- a/laplace/curvature/backpack.py
+++ b/laplace/curvature/backpack.py
@@ -1,3 +1,5 @@
+from typing import Tuple
+
 import torch
 
 from backpack import backpack, extend, memory_cleanup
@@ -131,7 +133,7 @@ class BackPackGGN(BackPackInterface, GGNInterface):
 
         return self.factor * loss.detach(), self.factor * dggn
 
-    def kron(self, X, y, N, **kwargs) -> [torch.Tensor, Kron]:
+    def kron(self, X, y, N, **kwargs) -> Tuple[torch.Tensor, Kron]:
         context = KFAC if self.stochastic else KFLR
         f = self.model(X)
         # Assumes that the last dimension of f is of size outputs.


### PR DESCRIPTION
Needed for, e.g., language data with multiple leading dimensions `(batch_size, n_tokens, ...)`. We assume that the last dimension of the model outputs is of size `n_outputs` (consistent with ASDL); hence, we can flatten all other dimensions into the batch dimension.