### PR TITLE
Add `asdl_fisher_kwargs` argument

### DIFF
--- a/laplace/baselaplace.py
+++ b/laplace/baselaplace.py
@@ -689,7 +689,7 @@ class ParametricLaplace(BaseLaplace):
         for sample in self.sample(n_samples):
             vector_to_parameters(sample, self.params)
             logits = self.model(X.to(self._device), **model_kwargs).detach()
-            py += 1/n_samples * torch.softmax(logits, dim=-1)
+            py += torch.softmax(logits, dim=-1) / n_samples
         vector_to_parameters(self.mean, self.params)
         return py
 

--- a/laplace/baselaplace.py
+++ b/laplace/baselaplace.py
@@ -40,7 +40,8 @@ class BaseLaplace:
         set the number of MC samples for stochastic approximations.
     """
     def __init__(self, model, likelihood, sigma_noise=1., prior_precision=1.,
-                 prior_mean=0., temperature=1., backend=None, backend_kwargs=None):
+                 prior_mean=0., temperature=1., backend=None, backend_kwargs=None,
+                 asdl_fisher_kwargs=None):
         if likelihood not in ['classification', 'regression']:
             raise ValueError(f'Invalid likelihood type {likelihood}')
 
@@ -75,6 +76,7 @@ class BaseLaplace:
         self._backend = None
         self._backend_cls = backend
         self._backend_kwargs = dict() if backend_kwargs is None else backend_kwargs
+        self._asdl_fisher_kwargs = dict() if asdl_fisher_kwargs is None else asdl_fisher_kwargs
 
         # log likelihood = g(loss)
         self.loss = 0.
@@ -351,9 +353,11 @@ class ParametricLaplace(BaseLaplace):
     """
 
     def __init__(self, model, likelihood, sigma_noise=1., prior_precision=1.,
-                 prior_mean=0., temperature=1., backend=None, backend_kwargs=None):
+                 prior_mean=0., temperature=1., backend=None, backend_kwargs=None,
+                 asdl_fisher_kwargs=None):
         super().__init__(model, likelihood, sigma_noise, prior_precision,
-                         prior_mean, temperature, backend, backend_kwargs)
+                         prior_mean, temperature, backend, backend_kwargs,
+                         asdl_fisher_kwargs)
         if not hasattr(self, 'H'):
             self._init_H()
             # posterior mean/mode
@@ -845,17 +849,18 @@ class KronLaplace(ParametricLaplace):
 
     def __init__(self, model, likelihood, sigma_noise=1., prior_precision=1.,
                  prior_mean=0., temperature=1., backend=None, damping=False,
-                 **backend_kwargs):
+                 backend_kwargs=None, asdl_fisher_kwargs=None):
         self.damping = damping
         self.H_facs = None
         super().__init__(model, likelihood, sigma_noise, prior_precision,
-                         prior_mean, temperature, backend, **backend_kwargs)
+                         prior_mean, temperature, backend, backend_kwargs,
+                         asdl_fisher_kwargs)
 
     def _init_H(self):
         self.H = Kron.init_from_model(self.params, self._device)
 
     def _curv_closure(self, X, y, N):
-        return self.backend.kron(X, y, N=N)
+        return self.backend.kron(X, y, N=N, **self._asdl_fisher_kwargs)
 
     @staticmethod
     def _rescale_factors(kron, factor):
@@ -1038,7 +1043,7 @@ class DiagLaplace(ParametricLaplace):
         self.H = torch.zeros(self.n_params, device=self._device)
 
     def _curv_closure(self, X, y, N):
-        return self.backend.diag(X, y, N=N)
+        return self.backend.diag(X, y, N=N, **self._asdl_fisher_kwargs)
 
     @property
     def posterior_precision(self):

--- a/laplace/curvature/asdl.py
+++ b/laplace/curvature/asdl.py
@@ -122,7 +122,8 @@ class AsdlInterface(CurvatureInterface):
                 F[1] *= 1/N
         return kron
 
-    def diag(self, X, y, **kwargs):
+    def diag(self, X, y, N=None, **kwargs):
+        del N
         if self.last_layer:
             _, X = self.model.forward_with_features(X)
         cfg = FisherConfig(fisher_type=self._ggn_type, loss_type=self.loss_type,

--- a/laplace/curvature/asdl.py
+++ b/laplace/curvature/asdl.py
@@ -126,7 +126,7 @@ class AsdlInterface(CurvatureInterface):
         if self.last_layer:
             _, X = self.model.forward_with_features(X)
         cfg = FisherConfig(fisher_type=self._ggn_type, loss_type=self.loss_type,
-                           fisher_shapes=[SHAPE_DIAG], data_size=1)
+                           fisher_shapes=[SHAPE_DIAG], data_size=1, **kwargs)
         fisher_maker = get_fisher_maker(self.model, cfg)
         y = y if self.loss_type == LOSS_MSE else y.view(-1)
         if 'emp' in self._ggn_type:
@@ -158,7 +158,7 @@ class AsdlInterface(CurvatureInterface):
         if self.last_layer:
             _, X = self.model.forward_with_features(X)
         cfg = FisherConfig(fisher_type=self._ggn_type, loss_type=self.loss_type,
-                           fisher_shapes=[SHAPE_KRON], data_size=1)
+                           fisher_shapes=[SHAPE_KRON], data_size=1, **kwargs)
         fisher_maker = get_fisher_maker(self.model, cfg)
         y = y if self.loss_type == LOSS_MSE else y.view(-1)
         if 'emp' in self._ggn_type:

--- a/laplace/lllaplace.py
+++ b/laplace/lllaplace.py
@@ -120,16 +120,27 @@ class LLLaplace(ParametricLaplace):
         f_var = self.functional_variance(Js)
         return f_mu.detach(), f_var.detach()
 
-    def _nn_predictive_samples(self, X, n_samples=100, softmax_temp=1):
+    def _nn_predictive_samples(self, X, n_samples=100, **model_kwargs):
         fs = list()
         for sample in self.sample(n_samples):
             vector_to_parameters(sample, self.model.last_layer.parameters())
-            fs.append(self.model(X.to(self._device)).detach())
+            # TODO: Implement with a single forward pass until last layer.
+            fs.append(self.model(X.to(self._device), **model_kwargs).detach())
         vector_to_parameters(self.mean, self.model.last_layer.parameters())
         fs = torch.stack(fs)
         if self.likelihood == 'classification':
-            fs = torch.softmax(fs/softmax_temp, dim=-1)
+            fs = torch.softmax(fs, dim=-1)
         return fs
+
+    def _nn_predictive_classification(self, X, n_samples=100, **model_kwargs):
+        py = 0
+        for sample in self.sample(n_samples):
+            vector_to_parameters(sample, self.model.last_layer.parameters())
+            # TODO: Implement with a single forward pass until last layer.
+            logits = self.model(X.to(self._device), **model_kwargs).detach()
+            py += torch.softmax(logits, dim=-1) / n_samples
+        vector_to_parameters(self.mean, self.model.last_layer.parameters())
+        return py
 
     @property
     def prior_precision_diag(self):

--- a/laplace/lllaplace.py
+++ b/laplace/lllaplace.py
@@ -56,7 +56,9 @@ class LLLaplace(ParametricLaplace):
     """
     def __init__(self, model, likelihood, sigma_noise=1., prior_precision=1.,
                  prior_mean=0., temperature=1., backend=None, last_layer_name=None,
-                 backend_kwargs=None):
+                 backend_kwargs=None, asdl_fisher_kwargs=None):
+        if asdl_fisher_kwargs is not None:
+            raise ValueError('Last-layer Laplace does not support asdl_fisher_kwargs.')
         self.H = None
         super().__init__(model, likelihood, sigma_noise=sigma_noise, prior_precision=1.,
                          prior_mean=0., temperature=temperature, backend=backend,

--- a/laplace/subnetlaplace.py
+++ b/laplace/subnetlaplace.py
@@ -66,7 +66,9 @@ class SubnetLaplace(ParametricLaplace):
         set the number of MC samples for stochastic approximations.
     """
     def __init__(self, model, likelihood, subnetwork_indices, sigma_noise=1., prior_precision=1.,
-                 prior_mean=0., temperature=1., backend=None, backend_kwargs=None):
+                 prior_mean=0., temperature=1., backend=None, backend_kwargs=None, asdl_fisher_kwargs=None):
+        if asdl_fisher_kwargs is not None:
+            raise ValueError('Subnetwork Laplace does not support asdl_fisher_kwargs.')
         self.H = None
         super().__init__(model, likelihood, sigma_noise=sigma_noise,
                          prior_precision=prior_precision, prior_mean=prior_mean,


### PR DESCRIPTION
Add `asdl_fisher_kwargs` argument to be able to specify ASDL's `FisherConfig` values like `kfac_linear`, `diag_A/B`, and `autocast`.

@AlexImmer Can you check that my changes in line 848 and 852 of `baselaplace.py` don't break anything? Not sure why this was differently implemented here than in other places.

~Also, I have noticed that the tests are broken, which is really weird since I'm almost certain that I ran them successfully for my last PR. I went back to [this commit](https://github.com/AlexImmer/Laplace/commit/99278beb81d613bccac934b11158e7066ec8d34d) and they are already broken at this point. We will have to look into this.~

~_Edit:_ Ok, just checked and this PR seems to break a few more tests than the ones that were broken already, so maybe do not merge yet, will fix this tomorrow.~