### PR TITLE
Running metrics

### DIFF
--- a/laplace/baselaplace.py
+++ b/laplace/baselaplace.py
@@ -290,10 +290,15 @@ class BaseLaplace:
             try:
                 result = validate(
                     self, val_loader, loss, pred_type=pred_type,
-                    link_approx=link_approx, n_samples=n_samples
+                    link_approx=link_approx, n_samples=n_samples,
+                    loss_with_var=loss_with_var
                 )
             except RuntimeError:
                 result = np.inf
+
+            if progress_bar:
+                pbar.set_description(f'[prior_prec: {prior_prec:.3e}, loss: {result:.3f}]')
+
             results.append(result)
             prior_precs.append(prior_prec)
         return prior_precs[np.argmin(results)]

--- a/laplace/baselaplace.py
+++ b/laplace/baselaplace.py
@@ -269,7 +269,8 @@ class BaseLaplace:
             )
             self.prior_precision = self._gridsearch(
                 loss, interval, val_loader, pred_type=pred_type,
-                link_approx=link_approx, n_samples=n_samples, loss_with_var=cv_loss_with_var
+                link_approx=link_approx, n_samples=n_samples, loss_with_var=cv_loss_with_var,
+                progress_bar=progress_bar
             )
         else:
             raise ValueError('For now only marglik and CV is implemented.')

--- a/laplace/utils/__init__.py
+++ b/laplace/utils/__init__.py
@@ -3,6 +3,7 @@ from laplace.utils.feature_extractor import FeatureExtractor
 from laplace.utils.matrix import Kron, KronDecomposed
 from laplace.utils.swag import fit_diagonal_swag_var
 from laplace.utils.subnetmask import SubnetMask, RandomSubnetMask, LargestMagnitudeSubnetMask, LargestVarianceDiagLaplaceSubnetMask, LargestVarianceSWAGSubnetMask, ParamNameSubnetMask, ModuleNameSubnetMask, LastLayerSubnetMask
+from laplace.utils.metrics import RunningNLLMetric
 
 
 __all__ = ['get_nll', 'validate', 'parameters_per_layer', 'invsqrt_precision', 'kron',
@@ -11,4 +12,4 @@ __all__ = ['get_nll', 'validate', 'parameters_per_layer', 'invsqrt_precision', '
            'Kron', 'KronDecomposed',
 		   'fit_diagonal_swag_var',
 		   'SubnetMask', 'RandomSubnetMask', 'LargestMagnitudeSubnetMask', 'LargestVarianceDiagLaplaceSubnetMask',
-		   'LargestVarianceSWAGSubnetMask', 'ParamNameSubnetMask', 'ModuleNameSubnetMask', 'LastLayerSubnetMask']
+		   'LargestVarianceSWAGSubnetMask', 'ParamNameSubnetMask', 'ModuleNameSubnetMask', 'LastLayerSubnetMask', 'RunningNLLMetric']

--- a/laplace/utils/metrics.py
+++ b/laplace/utils/metrics.py
@@ -1,0 +1,40 @@
+import torch
+from torch.nn import functional as F
+from torchmetrics import Metric
+
+
+class RunningNLLMetric(Metric):
+    """
+    NLL metrics that
+
+    Parameters
+    ----------
+    ignore_index: int, default = -100
+        which class label to ignore when computing the NLL loss
+    """
+    def __init__(self, ignore_index=-100):
+        super().__init__()
+        self.add_state('nll_sum', default=torch.tensor(0.), dist_reduce_fx='sum')
+        self.add_state('n_valid_labels', default=torch.tensor(0.), dist_reduce_fx='sum')
+        self.ignore_index = ignore_index
+
+    def update(self, probs: torch.Tensor, targets: torch.Tensor) -> None:
+        """
+        Parameters
+        ----------
+        probs: torch.Tensor
+            probability tensor of shape (..., n_classes)
+
+        targets: torch.Tensor
+            integer tensor of shape (...)
+        """
+        probs = probs.view(-1, probs.shape[-1])
+        targets = targets.view(-1)
+
+        self.nll_sum += F.nll_loss(
+            probs.log(), targets, ignore_index=self.ignore_index, reduction='sum'
+        ).item()
+        self.n_valid_labels += (targets != self.ignore_index).sum().item()
+
+    def compute(self):
+        return self.nll_sum / self.n_valid_labels

--- a/laplace/utils/metrics.py
+++ b/laplace/utils/metrics.py
@@ -33,8 +33,8 @@ class RunningNLLMetric(Metric):
 
         self.nll_sum += F.nll_loss(
             probs.log(), targets, ignore_index=self.ignore_index, reduction='sum'
-        ).item()
-        self.n_valid_labels += (targets != self.ignore_index).sum().item()
+        )
+        self.n_valid_labels += (targets != self.ignore_index).sum()
 
     def compute(self):
         return self.nll_sum / self.n_valid_labels

--- a/laplace/utils/utils.py
+++ b/laplace/utils/utils.py
@@ -7,6 +7,7 @@ from torch.nn.utils import parameters_to_vector
 from torch.nn import BatchNorm1d, BatchNorm2d, BatchNorm3d
 from torch.distributions.multivariate_normal import _precision_to_scale_tril
 from torchmetrics import Metric
+from collections import UserDict
 
 
 __all__ = ['get_nll', 'validate', 'parameters_per_layer', 'invsqrt_precision', 'kron',
@@ -27,7 +28,8 @@ def validate(laplace, val_loader, loss, pred_type='glm', link_approx='probit', n
         output_means, output_vars = list(), list()
         targets = list()
 
-    for X, y in val_loader:
+    for data in val_loader:
+        X, y = (data['input_ids'], data['labels']) if isinstance(data, UserDict) else data
         X, y = X.to(laplace._device), y.to(laplace._device)
         out = laplace(
             X, pred_type=pred_type,

--- a/laplace/utils/utils.py
+++ b/laplace/utils/utils.py
@@ -8,6 +8,7 @@ from torch.nn import BatchNorm1d, BatchNorm2d, BatchNorm3d
 from torch.distributions.multivariate_normal import _precision_to_scale_tril
 from torchmetrics import Metric
 from collections import UserDict
+import math
 
 
 __all__ = ['get_nll', 'validate', 'parameters_per_layer', 'invsqrt_precision', 'kron',
@@ -19,10 +20,10 @@ def get_nll(out_dist, targets):
 
 
 @torch.no_grad()
-def validate(laplace, val_loader, loss, pred_type='glm', link_approx='probit', n_samples=100) -> float:
+def validate(laplace, val_loader, loss, pred_type='glm', link_approx='probit', n_samples=100, loss_with_var=False) -> float:
     laplace.model.eval()
     assert callable(loss) or isinstance(loss, Metric)
-    is_offline = loss
+    is_offline = not isinstance(loss, Metric)
 
     if is_offline:
         output_means, output_vars = list(), list()

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ install_requires =
     torchaudio
     backpack-for-pytorch
     asdl
+    torchmetrics
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
 python_requires = >=3.8
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,44 @@
+import torch
+from torch.nn import functional as F
+from laplace.utils import RunningNLLMetric
+import math
+
+
+def test_running_nll_metric():
+    metric = RunningNLLMetric()
+    all_probs, all_targets = [], []
+
+    for _ in range(10):
+        probs = torch.softmax(torch.randn(3, 5, 10), dim=-1)
+        targets = torch.randint(10, size=(3, 5))
+        metric.update(probs, targets)
+        all_probs.append(probs)
+        all_targets.append(targets)
+
+    all_probs, all_targets = torch.cat(all_probs, 0), torch.cat(all_targets, 0)
+
+    nll_running = metric.compute().item()
+    nll_offline = F.nll_loss(all_probs.log().flatten(end_dim=-2), all_targets.flatten()).item()
+
+    assert math.isclose(nll_running, nll_offline)
+
+
+def test_running_nll_metric_ignore_idx():
+    ignore_idx = -1232
+    metric_orig = RunningNLLMetric()
+    metric_ignore = RunningNLLMetric(ignore_index=ignore_idx)
+
+    for _ in range(10):
+        probs = torch.softmax(torch.randn(3, 5, 10), dim=-1)
+        targets_orig = torch.randint(10, size=(3, 5))
+        targets_ignore = targets_orig.clone()
+        metric_orig.update(probs, targets_orig)
+
+        mask = torch.FloatTensor(*targets_ignore.shape).uniform_() > 0.8  # ~80% zeros
+        targets_ignore[mask] = ignore_idx  # ~80% changed to ignore_idx
+        metric_ignore.update(probs, targets_ignore)
+
+    nll_orig = metric_orig.compute().item()
+    nll_ignore = metric_ignore.compute().item()
+
+    assert nll_orig > nll_ignore


### PR DESCRIPTION
Support running metrics in cross validation of prior precision. Rationale: gathering data then computing metric is very expensive if `n_data` is very large.  

There are some failed tests for LLLaplace, but I think they are unrelated.