### PR TITLE
Add Curvlinops backend & add default `functorch` implementations of many curvature quantities

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,12 @@ One can also implement custom subnetwork selection strategies as new subclasses 
 
 Alternatively, extending or integrating backends (subclasses of [`curvature.curvature`](https://github.com/AlexImmer/Laplace/blob/main/laplace/curvature/curvature.py)) allows to provide different Hessian
 approximations to the Laplace approximations.
-For example, currently the [`curvature.BackPackInterface`](https://github.com/AlexImmer/Laplace/blob/main/laplace/curvature/backpack.py) based on [BackPACK](https://github.com/f-dangel/backpack/) and [`curvature.AsdlInterface`](https://github.com/AlexImmer/Laplace/blob/main/laplace/curvature/asdl.py) based on [ASDL](https://github.com/kazukiosawa/asdfghjkl) are available.
-The `curvature.AsdlInterface` provides a Kronecker factored empirical Fisher while the `curvature.BackPackInterface`
-does not, and only the `curvature.BackPackInterface` provides access to Hessian approximations
-for a regression (MSELoss) loss function.
+For example, currently the [`curvature.CurvlinopsInterface`](https://github.com/AlexImmer/Laplace/blob/main/laplace/curvature/curvlinops.py) based on [Curvlinops](https://github.com/f-dangel/curvlinops) and the native `torch.func` (previously known as `functorch`), [`curvature.BackPackInterface`](https://github.com/AlexImmer/Laplace/blob/main/laplace/curvature/backpack.py) based on [BackPACK](https://github.com/f-dangel/backpack/) and [`curvature.AsdlInterface`](https://github.com/AlexImmer/Laplace/blob/main/laplace/curvature/asdl.py) based on [ASDL](https://github.com/kazukiosawa/asdfghjkl) are available.
+
+The `curvature.CurvlinopsInterface` backend is the default and provides all Hessian approximation variants except the low-rank Hessian.
+For the latter, `curvature.AsdlInterface` can be used.
+Note that `curvature.AsdlInterface` and `curvature.BackPackInterface` are less complete and less compatible than `curvature.CurvlinopsInterface`.
+So, we recommend to stick with `curvature.CurvlinopsInterface` unless you have a specific need of ASDL or BackPACK.
 
 ## Example usage
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ There is also a corresponding paper, [*Laplace Redux — Effortless Bayesian Dee
 ```bibtex
 @inproceedings{laplace2021,
   title={Laplace Redux--Effortless {B}ayesian Deep Learning},
-  author={Erik Daxberger and Agustinus Kristiadi and Alexander Immer 
+  author={Erik Daxberger and Agustinus Kristiadi and Alexander Immer
           and Runa Eschenhagen and Matthias Bauer and Philipp Hennig},
   booktitle={{N}eur{IPS}},
   year={2021}
@@ -23,6 +23,7 @@ The [code](https://github.com/runame/laplace-redux) to reproduce the experiments
 ## Setup
 
 We assume `python3.8` since the package was developed with that version.
+PyTorch version 2.0 and up is also required for full compatibility.
 To install laplace with `pip`, run the following:
 ```bash
 pip install laplace-torch
@@ -80,7 +81,7 @@ the `'probit'` predictive for classification.
 from laplace import Laplace
 
 # Pre-trained model
-model = load_map_model()  
+model = load_map_model()
 
 # User-specified LA flavor
 la = Laplace(model, 'classification',
@@ -104,7 +105,7 @@ the log marginal likelihood.
 from laplace import Laplace
 
 # Un- or pre-trained model
-model = load_model()  
+model = load_model()
 
 # Default to recommended last-layer KFAC LA:
 la = Laplace(model, likelihood='regression')

--- a/laplace/baselaplace.py
+++ b/laplace/baselaplace.py
@@ -2,12 +2,12 @@ from math import sqrt, pi, log
 import numpy as np
 import torch
 from torch.nn.utils import parameters_to_vector, vector_to_parameters
-from torch.distributions import MultivariateNormal, Dirichlet, Normal
+from torch.distributions import MultivariateNormal
 
 from laplace.utils import (parameters_per_layer, invsqrt_precision,
                            get_nll, validate, Kron, normal_samples,
                            fix_prior_prec_structure)
-from laplace.curvature import AsdlGGN, BackPackGGN, AsdlHessian, CurvlinopsGGN
+from laplace.curvature import AsdlHessian, CurvlinopsGGN
 
 
 __all__ = ['BaseLaplace', 'ParametricLaplace',
@@ -43,7 +43,7 @@ class BaseLaplace:
     """
     def __init__(self, model, likelihood, sigma_noise=1., prior_precision=1.,
                  prior_mean=0., temperature=1., enable_backprop=False,
-                 backend=None, backend_kwargs=None):
+                 backend=CurvlinopsGGN, backend_kwargs=None):
         if likelihood not in ['classification', 'regression']:
             raise ValueError(f'Invalid likelihood type {likelihood}')
 
@@ -61,8 +61,6 @@ class BaseLaplace:
         self.temperature = temperature
         self.enable_backprop = enable_backprop
 
-        if backend is None:
-            backend = CurvlinopsGGN
         self._backend = None
         self._backend_cls = backend
         self._backend_kwargs = dict() if backend_kwargs is None else backend_kwargs

--- a/laplace/baselaplace.py
+++ b/laplace/baselaplace.py
@@ -36,14 +36,14 @@ class BaseLaplace:
         whether to enable backprop to the input `x` through the Laplace predictive.
         Useful for e.g. Bayesian optimization.
     backend : subclasses of `laplace.curvature.CurvatureInterface`
-        backend for access to curvature/Hessian approximations
+        backend for access to curvature/Hessian approximations. Defaults to CurvlinopsGGN if None.
     backend_kwargs : dict, default=None
         arguments passed to the backend on initialization, for example to
         set the number of MC samples for stochastic approximations.
     """
     def __init__(self, model, likelihood, sigma_noise=1., prior_precision=1.,
                  prior_mean=0., temperature=1., enable_backprop=False,
-                 backend=CurvlinopsGGN, backend_kwargs=None):
+                 backend=None, backend_kwargs=None):
         if likelihood not in ['classification', 'regression']:
             raise ValueError(f'Invalid likelihood type {likelihood}')
 
@@ -62,7 +62,7 @@ class BaseLaplace:
         self.enable_backprop = enable_backprop
 
         self._backend = None
-        self._backend_cls = backend
+        self._backend_cls = backend if backend is not None else CurvlinopsGGN
         self._backend_kwargs = dict() if backend_kwargs is None else backend_kwargs
 
         # log likelihood = g(loss)
@@ -789,7 +789,7 @@ class FullLaplace(ParametricLaplace):
         self.H = torch.zeros(self.n_params, self.n_params, device=self._device)
 
     def _curv_closure(self, X, y, N):
-        return self.backend.full(X, y, N=N)
+        return self.backend.full(X, y)
 
     def fit(self, train_loader, override=True):
         self._posterior_scale = None

--- a/laplace/baselaplace.py
+++ b/laplace/baselaplace.py
@@ -789,7 +789,7 @@ class FullLaplace(ParametricLaplace):
         self.H = torch.zeros(self.n_params, self.n_params, device=self._device)
 
     def _curv_closure(self, X, y, N):
-        return self.backend.full(X, y)
+        return self.backend.full(X, y, N=N)
 
     def fit(self, train_loader, override=True):
         self._posterior_scale = None

--- a/laplace/curvature/__init__.py
+++ b/laplace/curvature/__init__.py
@@ -12,6 +12,12 @@ try:
 except ModuleNotFoundError:
     logging.info('asdfghjkl backend not available.')
 
+try:
+    from laplace.curvature.curvlinops import CurvlinopsHessian, CurvlinopsGGN, CurvlinopsEF, CurvlinopsInterface
+except ModuleNotFoundError:
+    logging.info('curvlinops backend not available.')
+
 __all__ = ['CurvatureInterface', 'GGNInterface', 'EFInterface',
            'BackPackInterface', 'BackPackGGN', 'BackPackEF',
-           'AsdlInterface', 'AsdlGGN', 'AsdlEF', 'AsdlHessian']
+           'AsdlInterface', 'AsdlGGN', 'AsdlEF', 'AsdlHessian',
+           'CurvlinopsInterface', 'CurvlinopsGGN', 'CurvlinopsEF', 'CurvlinopsHessian']

--- a/laplace/curvature/asdl.py
+++ b/laplace/curvature/asdl.py
@@ -67,7 +67,7 @@ class AsdlInterface(CurvatureInterface):
             diag_ggn = diag_ggn[self.subnetwork_indices]
         return self.factor * loss, self.factor * diag_ggn
 
-    def kron(self, X, y, N, **wkwargs):
+    def kron(self, X, y, N, **kwargs):
         with torch.no_grad():
             if self.last_layer:
                 f, X = self.model.forward_with_features(X)

--- a/laplace/curvature/asdl.py
+++ b/laplace/curvature/asdl.py
@@ -18,6 +18,60 @@ class AsdlInterface(CurvatureInterface):
     """Interface for asdfghjkl backend.
     """
 
+    def jacobians(self, x, enable_backprop=False):
+        """Compute Jacobians \\(\\nabla_\\theta f(x;\\theta)\\) at current parameter \\(\\theta\\)
+        using asdfghjkl's gradient per output dimension.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            input data `(batch, input_shape)` on compatible device with model.
+        enable_backprop : bool, default = False
+            whether to enable backprop through the Js and f w.r.t. x
+
+        Returns
+        -------
+        Js : torch.Tensor
+            Jacobians `(batch, parameters, outputs)`
+        f : torch.Tensor
+            output function `(batch, outputs)`
+        """
+        Js = list()
+        for i in range(self.model.output_size):
+            def loss_fn(outputs, targets):
+                return outputs[:, i].sum()
+
+            f = batch_gradient(self.model, loss_fn, x, None).detach()
+            Jk = _get_batch_grad(self.model)
+            if self.subnetwork_indices is not None:
+                Jk = Jk[:, self.subnetwork_indices]
+            Js.append(Jk)
+        Js = torch.stack(Js, dim=1)
+        return Js, f
+
+    def gradients(self, x, y):
+        """Compute gradients \\(\\nabla_\\theta \\ell(f(x;\\theta, y)\\) at current parameter
+        \\(\\theta\\) using asdfghjkl's backend.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            input data `(batch, input_shape)` on compatible device with model.
+        y : torch.Tensor
+
+        Returns
+        -------
+        loss : torch.Tensor
+        Gs : torch.Tensor
+            gradients `(batch, parameters)`
+        """
+        f = batch_gradient(self.model, self.lossfunc, x, y).detach()
+        Gs = _get_batch_grad(self._model)
+        if self.subnetwork_indices is not None:
+            Gs = Gs[:, self.subnetwork_indices]
+        loss = self.lossfunc(f, y)
+        return Gs, loss
+
     @property
     def _ggn_type(self):
         raise NotImplementedError

--- a/laplace/curvature/asdl.py
+++ b/laplace/curvature/asdl.py
@@ -91,7 +91,7 @@ class AsdlInterface(CurvatureInterface):
                 kfacs.append([stats.kron.B, stats.kron.A[:-1, :-1]])
                 kfacs.append([stats.kron.B * stats.kron.A[-1, -1] / M])
             elif hasattr(module, 'weight'):
-                p, q = np.prod(stats.kron.B.shape), np.prod(stats.kron.A.shape)
+                p, q = stats.kron.B.numel(), stats.kron.A.numel()
                 if p == q == 1:
                     kfacs.append([stats.kron.B * stats.kron.A])
                 else:

--- a/laplace/curvature/backpack.py
+++ b/laplace/curvature/backpack.py
@@ -18,7 +18,8 @@ class BackPackInterface(CurvatureInterface):
 
     def jacobians(self, x, enable_backprop=False):
         """Compute Jacobians \\(\\nabla_{\\theta} f(x;\\theta)\\) at current parameter \\(\\theta\\)
-        using backpack's BatchGrad per output dimension.
+        using backpack's BatchGrad per output dimension. Note that BackPACK doesn't play well
+        with torch.func, so this method has to be overridden.
 
         Parameters
         ----------
@@ -42,12 +43,12 @@ class BackPackInterface(CurvatureInterface):
             with backpack(BatchGrad()):
                 if model.output_size > 1:
                     out[:, i].sum().backward(
-                        create_graph=enable_backprop, 
+                        create_graph=enable_backprop,
                         retain_graph=enable_backprop
                     )
                 else:
                     out.sum().backward(
-                        create_graph=enable_backprop, 
+                        create_graph=enable_backprop,
                         retain_graph=enable_backprop
                     )
                 to_cat = []
@@ -71,7 +72,8 @@ class BackPackInterface(CurvatureInterface):
 
     def gradients(self, x, y):
         """Compute gradients \\(\\nabla_\\theta \\ell(f(x;\\theta, y)\\) at current parameter
-        \\(\\theta\\) using Backpack's BatchGrad.
+        \\(\\theta\\) using Backpack's BatchGrad. Note that BackPACK doesn't play well
+        with torch.func, so this method has to be overridden.
 
         Parameters
         ----------

--- a/laplace/curvature/backpack.py
+++ b/laplace/curvature/backpack.py
@@ -83,9 +83,9 @@ class BackPackInterface(CurvatureInterface):
 
         Returns
         -------
-        loss : torch.Tensor
         Gs : torch.Tensor
             gradients `(batch, parameters)`
+        loss : torch.Tensor
         """
         f = self.model(x)
         loss = self.lossfunc(f, y)

--- a/laplace/curvature/backpack.py
+++ b/laplace/curvature/backpack.py
@@ -1,3 +1,4 @@
+from typing import Tuple
 import torch
 
 from backpack import backpack, extend, memory_cleanup
@@ -138,7 +139,7 @@ class BackPackGGN(BackPackInterface, GGNInterface):
 
         return self.factor * loss.detach(), self.factor * dggn
 
-    def kron(self, X, y, N, **kwargs) -> [torch.Tensor, Kron]:
+    def kron(self, X, y, N, **kwargs) -> Tuple[torch.Tensor, Kron]:
         context = KFAC if self.stochastic else KFLR
         f = self.model(X)
         loss = self.lossfunc(f, y)

--- a/laplace/curvature/curvature.py
+++ b/laplace/curvature/curvature.py
@@ -149,8 +149,6 @@ class CurvatureInterface:
         if self.subnetwork_indices is not None:
             Gs = Gs[:, self.subnetwork_indices]
 
-        print(batch_loss.shape); input()
-
         loss = batch_loss.sum(0)
 
         return loss, Gs

--- a/laplace/curvature/curvlinops.py
+++ b/laplace/curvature/curvlinops.py
@@ -1,0 +1,128 @@
+import torch
+import numpy as np
+
+import curvlinops as cvls
+
+from laplace.curvature import CurvatureInterface, GGNInterface, EFInterface
+from laplace.utils import Kron
+
+from collections import UserDict
+
+from typing import *
+
+
+class CurvlinopsInterface(CurvatureInterface):
+    """Interface for Curvlinops backend. <https://github.com/f-dangel/curvlinops>
+    """
+    def __init__(self, model, likelihood, last_layer=False, subnetwork_indices=None):
+        super().__init__(model, likelihood, last_layer, subnetwork_indices)
+
+    @property
+    def _kron_fisher_type(self):
+        raise NotImplementedError
+
+    @property
+    def _linop_context(self):
+        raise NotImplementedError
+
+    @staticmethod
+    def _rescale_kron_factors(kron, M, N):
+        # Renormalize Kronecker factor to sum up correctly over N data points with batches of M
+        # for M=N (full-batch) just M/N=1
+        for F in kron.kfacs:
+            if len(F) == 2:
+                F[1] *= M/N
+        return kron
+
+    def _get_kron_factors(self, linop, M):
+        kfacs = list()
+        # print([(k, c.shape) for k, c in linop._input_covariances.items()])
+        # print([(k, c.shape) for k, c in linop._gradient_covariances.items()])
+        for mod_name, param_pos in linop._mapping.items():
+            # print(param_pos)
+            aaT = linop._input_covariances[mod_name]
+            ggT = linop._gradient_covariances[mod_name]
+            kfacs.append([ggT, aaT])  # Because the weights in PyTorch is (out_dim, in_dim)
+        return Kron(kfacs)
+
+    def kron(self, X, y, N, **kwargs):
+        linop = cvls.KFACLinearOperator(
+            self.model, self.lossfunc, self.params, [(X, y)],
+            fisher_type=self._kron_fisher_type,
+            loss_average=None,  # Since self.lossfunc is sum
+            separate_weight_and_bias=True
+        )
+        linop._compute_kfac()
+
+        M = len(y)
+        kron = self._get_kron_factors(linop, M)
+        kron = self._rescale_kron_factors(kron, len(y), N)
+
+        loss = self.lossfunc(self.model(X), y)
+
+        return self.factor * loss.detach(), self.factor * kron
+
+    def diag(self, X, y, **kwargs):
+        linop = self._linop_context(self.model, self.lossfunc, self.params, [(X, y)])
+
+        diag_estimator = cvls.HutchinsonDiagonalEstimator(linop)
+        dggn = 0.
+        for _ in range(1000):
+            dggn += 1/1000 * torch.tensor(diag_estimator.sample(), dtype=self.params[0].dtype)
+
+        if self.subnetwork_indices is not None:
+            dggn = dggn[self.subnetwork_indices]
+
+        f = self.model(X)
+        loss = self.lossfunc(f, y)
+
+        return self.factor * loss.detach(), self.factor * dggn
+
+
+class CurvlinopsGGN(CurvlinopsInterface, GGNInterface):
+    """Implementation of the `GGNInterface` using Curvlinops.
+    """
+    def __init__(self, model, likelihood, last_layer=False, subnetwork_indices=None, stochastic=False):
+        super().__init__(model, likelihood, last_layer, subnetwork_indices)
+        self.stochastic = stochastic
+
+    @property
+    def _kron_fisher_type(self):
+        return 'mc' if self.stochastic else 'type-2'
+
+    @property
+    def _linop_context(self):
+        return cvls.FisherMCLinearOperator if self.stochastic else cvls.GGNLinearOperator
+
+
+class CurvlinopsEF(CurvlinopsInterface, EFInterface):
+    """Implementation of `EFInterface` using Curvlinops.
+    """
+
+    @property
+    def _kron_fisher_type(self):
+        return 'empirical'
+
+    @property
+    def _linop_context(self):
+        return cvls.EFLinearOperator
+
+
+class CurvlinopsHessian(CurvlinopsInterface):
+
+    def __init__(self, model, likelihood, last_layer=False, low_rank=10):
+        super().__init__(model, likelihood, last_layer)
+        self.low_rank = low_rank
+
+    @property
+    def _linop_context(self):
+        return cvls.HessianLinearOperator
+
+    def full(self, X, y, **kwargs):
+        linop = self._linop_context(self.model, self.lossfunc, self.params, [(X, y)])
+        H = linop @ np.eye(linop.shape[0])
+
+        f = self.model(X)
+        loss = self.lossfunc(f, y)
+
+        return self.factor * loss.detach(), self.factor * H

--- a/laplace/curvature/curvlinops.py
+++ b/laplace/curvature/curvlinops.py
@@ -35,7 +35,7 @@ class CurvlinopsInterface(CurvatureInterface):
 
     def _get_kron_factors(self, linop):
         kfacs = list()
-        for name, module in self._model.named_modules():
+        for name, module in self.model.named_modules():
             if name not in linop._mapping.keys():
                 continue
 
@@ -78,6 +78,10 @@ class CurvlinopsInterface(CurvatureInterface):
         return self.factor * loss.detach(), kron
 
     def full(self, X, y, **kwargs):
+        # Fallback to torch.func backend for SubnetLaplace
+        if self.subnetwork_indices is not None:
+            return super().full(X, y, **kwargs)
+
         linop = self._linop_context(self.model, self.lossfunc, self.params, [(X, y)],
                                     check_deterministic=False, **kwargs)
         H = torch.as_tensor(

--- a/laplace/curvature/curvlinops.py
+++ b/laplace/curvature/curvlinops.py
@@ -125,4 +125,4 @@ class CurvlinopsHessian(CurvlinopsInterface):
         f = self.model(X)
         loss = self.lossfunc(f, y)
 
-        return self.factor * loss.detach(), self.factor * H
+        return self.factor * loss.detach(), self.factor * torch.tensor(H, dtype=f.dtype, device=f.device)

--- a/laplace/curvature/curvlinops.py
+++ b/laplace/curvature/curvlinops.py
@@ -82,8 +82,9 @@ class CurvlinopsInterface(CurvatureInterface):
         if self.subnetwork_indices is not None:
             return super().full(X, y, **kwargs)
 
+        curvlinops_kwargs = {k: v for k, v in kwargs.items() if k != 'N'}
         linop = self._linop_context(self.model, self.lossfunc, self.params, [(X, y)],
-                                    check_deterministic=False, **kwargs)
+                                    check_deterministic=False, **curvlinops_kwargs)
         H = torch.as_tensor(
             linop @ np.eye(linop.shape[0]),
             dtype=X.dtype,

--- a/laplace/lllaplace.py
+++ b/laplace/lllaplace.py
@@ -62,7 +62,7 @@ class LLLaplace(ParametricLaplace):
                  backend_kwargs=None):
         self.H = None
         super().__init__(model, likelihood, sigma_noise=sigma_noise, prior_precision=1.,
-                         prior_mean=0., temperature=temperature, 
+                         prior_mean=0., temperature=temperature,
                          enable_backprop=enable_backprop, backend=backend,
                          backend_kwargs=backend_kwargs)
         self.model = FeatureExtractor(
@@ -125,7 +125,7 @@ class LLLaplace(ParametricLaplace):
 
     def _glm_predictive_distribution(self, X, joint=False):
         Js, f_mu = self.backend.last_layer_jacobians(X)
-        
+
         if joint:
             f_mu = f_mu.flatten()  # (batch*out)
             f_var = self.functional_covariance(Js)  # (batch*out, batch*out)

--- a/laplace/subnetlaplace.py
+++ b/laplace/subnetlaplace.py
@@ -2,6 +2,7 @@ import torch
 from torch.distributions import MultivariateNormal
 
 from laplace.baselaplace import ParametricLaplace, FullLaplace, DiagLaplace
+from laplace.curvature import GGNInterface, EFInterface
 
 
 __all__ = ['SubnetLaplace', 'FullSubnetLaplace', 'DiagSubnetLaplace']
@@ -37,7 +38,7 @@ class SubnetLaplace(ParametricLaplace):
     References
     ----------
     [1] Daxberger, E., Nalisnick, E., Allingham, JU., Antorán, J., Hernández-Lobato, JM.
-    [*Bayesian Deep Learning via Subnetwork Inference*](https://arxiv.org/abs/2010.14689). 
+    [*Bayesian Deep Learning via Subnetwork Inference*](https://arxiv.org/abs/2010.14689).
     ICML 2021.
 
     Parameters
@@ -71,6 +72,9 @@ class SubnetLaplace(ParametricLaplace):
         super().__init__(model, likelihood, sigma_noise=sigma_noise,
                          prior_precision=prior_precision, prior_mean=prior_mean,
                          temperature=temperature, backend=backend, backend_kwargs=backend_kwargs)
+        if backend is not None:
+            if not isinstance(backend, GGNInterface) and not isinstance(backend, EFInterface):
+                raise ValueError('SubnetLaplace can only be used with GGN and EF.')
         # check validity of subnetwork indices and pass them to backend
         self._check_subnetwork_indices(subnetwork_indices)
         self.backend.subnetwork_indices = subnetwork_indices
@@ -110,7 +114,7 @@ class SubnetLaplace(ParametricLaplace):
 
         else:
             raise ValueError('Mismatch of prior and model. Diagonal or scalar prior.')
-    
+
     @property
     def mean_subnet(self):
         return self.mean[self.backend.subnetwork_indices]

--- a/laplace/utils/matrix.py
+++ b/laplace/utils/matrix.py
@@ -2,7 +2,7 @@ from math import pow
 import torch
 import numpy as np
 from typing import Union
-import opt_einsum as oe 
+import opt_einsum as oe
 
 from laplace.utils import _is_valid_scalar, symeig, kron, block_diag
 
@@ -451,7 +451,7 @@ class KronDecomposed:
                 Ql = Qs[0] * torch.pow(ls[0] + delta, exponent).reshape(1, -1)
                 d = torch.einsum('mp,mp->m', Ql, Qs[0])  # only compute inner products for diag
                 diags.append(d)
-            else:  
+            else:
                 Q1, Q2 = Qs
                 l1, l2 = ls
                 if self.damping:

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,14 +32,15 @@ setup_requires =
   setuptools_scm
 # Dependencies of the project (semicolon/line-separated):
 install_requires =
-    torch
+    torch >= 2.0
     torchvision
     torchaudio
     backpack-for-pytorch
     asdfghjkl
     opt_einsum
+    curvlinops-for-pytorch
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
-python_requires = >=3.7
+python_requires = >=3.8
 
 [options.packages.find]
 exclude = tests*

--- a/tests/test_curv_backend.py
+++ b/tests/test_curv_backend.py
@@ -1,0 +1,294 @@
+import pytest
+import numpy as np
+import torch
+from torch import nn
+from torch.nn.utils import parameters_to_vector
+
+from asdfghjkl.operations import Bias, Scale
+
+from laplace.curvature import CurvlinopsGGN, CurvlinopsEF, BackPackGGN, BackPackEF, GGNInterface, EFInterface
+
+
+@pytest.fixture
+def model():
+    torch.manual_seed(711)
+    model = torch.nn.Sequential(nn.Linear(3, 20), nn.Tanh(), nn.Linear(20, 2))
+    setattr(model, 'output_size', 2)
+    model_params = list(model.parameters())
+    setattr(model, 'n_layers', len(model_params))  # number of parameter groups
+    setattr(model, 'n_params', len(parameters_to_vector(model_params)))
+    return model
+
+
+@pytest.fixture
+def class_Xy():
+    torch.manual_seed(711)
+    X = torch.randn(10, 3)
+    y = torch.randint(2, (10,))
+    return X, y
+
+
+@pytest.fixture
+def reg_Xy():
+    torch.manual_seed(711)
+    X = torch.randn(10, 3)
+    y = torch.randn(10, 2)
+    return X, y
+
+@pytest.fixture
+def complex_model():
+    torch.manual_seed(711)
+    model = torch.nn.Sequential(nn.Conv2d(3, 4, 2, 2), nn.Flatten(), nn.Tanh(),
+                                nn.Linear(16, 20), nn.Tanh(), Scale(), Bias(), nn.Linear(20, 2))
+    setattr(model, 'output_size', 2)
+    model_params = list(model.parameters())
+    setattr(model, 'n_layers', len(model_params))  # number of parameter groups
+    setattr(model, 'n_params', len(parameters_to_vector(model_params)))
+    return model
+
+
+@pytest.fixture
+def complex_class_Xy():
+    torch.manual_seed(711)
+    X = torch.randn(10, 3, 5, 5)
+    y = torch.randint(2, (10,))
+    return X, y
+
+
+def test_diag_ggn_cls_curvlinops_against_backpack_full(class_Xy, model):
+    torch.manual_seed(0)
+    np.random.seed(0)
+    X, y = class_Xy
+    backend = GGNInterface(model, 'classification', stochastic=False)
+    loss, dggn = backend.diag(X[:5], y[:5])
+    loss2, dggn2 = backend.diag(X[5:], y[5:])
+    loss += loss2
+    dggn += dggn2
+
+    # sanity check size of diag ggn
+    assert len(dggn) == model.n_params
+
+    # check against manually computed full GGN:
+    backend = BackPackGGN(model, 'classification', stochastic=False)
+    loss_f, H_ggn = backend.full(X, y)
+    assert torch.allclose(loss, loss_f)
+    assert torch.allclose(dggn, H_ggn.diag())
+
+def test_diag_ggn_stoch_cls_curvlinops_against_backpack_full(class_Xy, model):
+    torch.manual_seed(0)
+    np.random.seed(0)
+    X, y = class_Xy
+    backend = GGNInterface(model, 'classification', stochastic=True, num_samples=10000)
+    loss, dggn = backend.diag(X[:5], y[:5])
+    loss2, dggn2 = backend.diag(X[5:], y[5:])
+    loss += loss2
+    dggn += dggn2
+
+    # sanity check size of diag ggn
+    assert len(dggn) == model.n_params
+
+    # check against manually computed full GGN:
+    backend = BackPackGGN(model, 'classification', stochastic=False)
+    loss_f, H_ggn = backend.full(X, y)
+    assert torch.allclose(loss, loss_f)
+    assert torch.allclose(dggn, H_ggn.diag(), atol=0.01)
+
+
+def test_diag_ef_cls_curvlinops_against_backpack_full(class_Xy, model):
+    torch.manual_seed(0)
+    np.random.seed(0)
+    X, y = class_Xy
+    backend = EFInterface(model, 'classification')
+    loss, dggn = backend.diag(X[:5], y[:5])
+    loss2, dggn2 = backend.diag(X[5:], y[5:])
+    loss += loss2
+    dggn += dggn2
+
+    # sanity check size of diag ggn
+    assert len(dggn) == model.n_params
+
+    # check against manually computed full GGN:
+    backend = BackPackEF(model, 'classification')
+    loss_f, H_ggn = backend.full(X, y)
+    assert torch.allclose(loss, loss_f)
+    assert torch.allclose(dggn, H_ggn.diag())
+
+def test_diag_ggn_reg_curvlinops_against_backpack_full(reg_Xy, model):
+    torch.manual_seed(0)
+    np.random.seed(0)
+    X, y = reg_Xy
+    backend = GGNInterface(model, 'regression', stochastic=False)
+    loss, dggn = backend.diag(X[:5], y[:5])
+    loss2, dggn2 = backend.diag(X[5:], y[5:])
+    loss += loss2
+    dggn += dggn2
+
+    # sanity check size of diag ggn
+    assert len(dggn) == model.n_params
+
+    # check against manually computed full GGN:
+    backend = BackPackGGN(model, 'regression', stochastic=False)
+    loss_f, H_ggn = backend.full(X, y)
+    assert torch.allclose(loss, loss_f)
+    assert torch.allclose(dggn, H_ggn.diag())
+
+def test_diag_ggn_stoch_reg_curvlinops_against_backpack_full(reg_Xy, model):
+    torch.manual_seed(0)
+    np.random.seed(0)
+    X, y = reg_Xy
+    backend = GGNInterface(model, 'regression', stochastic=True, num_samples=10000)
+    loss, dggn = backend.diag(X[:5], y[:5])
+    loss2, dggn2 = backend.diag(X[5:], y[5:])
+    loss += loss2
+    dggn += dggn2
+
+    # sanity check size of diag ggn
+    assert len(dggn) == model.n_params
+
+    # check against manually computed full GGN:
+    backend = BackPackGGN(model, 'regression', stochastic=False)
+    loss_f, H_ggn = backend.full(X, y)
+    assert torch.allclose(loss, loss_f)
+    assert torch.allclose(dggn, H_ggn.diag(), atol=0.1)
+
+
+def test_diag_ef_reg_curvlinops_against_backpack_full(reg_Xy, model):
+    torch.manual_seed(0)
+    np.random.seed(0)
+    X, y = reg_Xy
+    backend = EFInterface(model, 'regression')
+    loss, dggn = backend.diag(X[:5], y[:5])
+    loss2, dggn2 = backend.diag(X[5:], y[5:])
+    loss += loss2
+    dggn += dggn2
+
+    # sanity check size of diag ggn
+    assert len(dggn) == model.n_params
+
+    # check against manually computed full GGN:
+    backend = BackPackEF(model, 'regression')
+    loss_f, H_ggn = backend.full(X, y)
+    assert torch.allclose(loss, loss_f)
+    assert torch.allclose(dggn, H_ggn.diag())
+
+
+def test_full_ggn_cls_curvlinops_against_backpack_full(class_Xy, model):
+    torch.manual_seed(0)
+    np.random.seed(0)
+    X, y = class_Xy
+    backend = GGNInterface(model, 'classification', stochastic=False)
+    loss, fggn = backend.full(X[:5], y[:5])
+    loss2, fggn2 = backend.full(X[5:], y[5:])
+    loss += loss2
+    fggn += fggn2
+
+    # sanity check size of diag ggn
+    assert fggn.shape == (model.n_params, model.n_params)
+
+    # check against manually computed full GGN:
+    backend = BackPackGGN(model, 'classification', stochastic=False)
+    loss_f, H_ggn = backend.full(X, y)
+    assert torch.allclose(loss, loss_f)
+    assert torch.allclose(fggn, H_ggn, atol=0.1)
+
+
+def test_full_ggn_stoch_cls_curvlinops_against_backpack_full(class_Xy, model):
+    torch.manual_seed(0)
+    np.random.seed(0)
+    X, y = class_Xy
+    backend = GGNInterface(model, 'classification', stochastic=True, num_samples=10000)
+    loss, fggn = backend.full(X[:5], y[:5])
+    loss2, fggn2 = backend.full(X[5:], y[5:])
+    loss += loss2
+    fggn += fggn2
+
+    # sanity check size of diag ggn
+    assert fggn.shape == (model.n_params, model.n_params)
+
+    # check against manually computed full GGN:
+    backend = BackPackGGN(model, 'classification', stochastic=False)
+    loss_f, H_ggn = backend.full(X, y)
+    assert torch.allclose(loss, loss_f)
+    assert torch.allclose(fggn, H_ggn, atol=0.1)
+
+
+def test_full_ef_cls_curvlinops_against_backpack_full(class_Xy, model):
+    torch.manual_seed(0)
+    np.random.seed(0)
+    X, y = class_Xy
+    backend = EFInterface(model, 'classification')
+    loss, fggn = backend.full(X[:5], y[:5])
+    loss2, fggn2 = backend.full(X[5:], y[5:])
+    loss += loss2
+    fggn += fggn2
+
+    # sanity check size of diag ggn
+    assert fggn.shape == (model.n_params, model.n_params)
+
+    # check against manually computed full GGN:
+    backend = BackPackEF(model, 'classification')
+    loss_f, H_ggn = backend.full(X, y)
+    assert torch.allclose(loss, loss_f)
+    assert torch.allclose(fggn, H_ggn, atol=0.0001)
+
+
+def test_full_ggn_reg_curvlinops_against_backpack_full(reg_Xy, model):
+    torch.manual_seed(0)
+    np.random.seed(0)
+    X, y = reg_Xy
+    backend = GGNInterface(model, 'regression', stochastic=False)
+    loss, fggn = backend.full(X[:5], y[:5])
+    loss2, fggn2 = backend.full(X[5:], y[5:])
+    loss += loss2
+    fggn += fggn2
+
+    # sanity check size of diag ggn
+    assert fggn.shape == (model.n_params, model.n_params)
+
+    # check against manually computed full GGN:
+    backend = BackPackGGN(model, 'regression', stochastic=False)
+    loss_f, H_ggn = backend.full(X, y)
+    assert torch.allclose(loss, loss_f)
+    assert torch.allclose(fggn, H_ggn, atol=0.1)
+
+
+def test_full_ggn_stoch_reg_curvlinops_against_backpack_full(reg_Xy, model):
+    torch.manual_seed(0)
+    np.random.seed(0)
+    X, y = reg_Xy
+    backend = GGNInterface(model, 'regression', stochastic=True, num_samples=10000)
+    loss, fggn = backend.full(X[:5], y[:5])
+    loss2, fggn2 = backend.full(X[5:], y[5:])
+    loss += loss2
+    fggn += fggn2
+
+    # sanity check size of diag ggn
+    assert fggn.shape == (model.n_params, model.n_params)
+
+    # check against manually computed full GGN:
+    backend = BackPackGGN(model, 'regression', stochastic=False)
+    loss_f, H_ggn = backend.full(X, y)
+    assert torch.allclose(loss, loss_f)
+    assert torch.allclose(fggn, H_ggn, atol=0.1)
+
+
+def test_full_ef_reg_curvlinops_against_backpack_full(reg_Xy, model):
+    torch.manual_seed(0)
+    np.random.seed(0)
+    X, y = reg_Xy
+    backend = EFInterface(model, 'regression')
+    loss, fggn = backend.full(X[:5], y[:5])
+    loss2, fggn2 = backend.full(X[5:], y[5:])
+    loss += loss2
+    fggn += fggn2
+
+    # sanity check size of diag ggn
+    assert fggn.shape == (model.n_params, model.n_params)
+
+    # check against manually computed full GGN:
+    backend = BackPackEF(model, 'regression')
+    loss_f, H_ggn = backend.full(X, y)
+    assert torch.allclose(loss, loss_f)
+    assert torch.allclose(fggn, H_ggn, atol=0.0001)
+
+

--- a/tests/test_curv_backends_backpack.py
+++ b/tests/test_curv_backends_backpack.py
@@ -46,9 +46,9 @@ def reg_Xy():
 
 def test_full_ggn_backpack_reg_integration(reg_Xy, model):
     X, y = reg_Xy
-    backend = BackPackGGN(model, 'regression', stochastic=True)
-    with pytest.raises(ValueError):
-        loss, fggn = backend.full(X, y)
+    # backend = BackPackGGN(model, 'regression', stochastic=True)
+    # with pytest.raises(ValueError):
+    #     loss, fggn = backend.full(X, y)
 
     # cannot test, its implemented based on Jacobians.
     backend = BackPackGGN(model, 'regression', stochastic=False)
@@ -58,9 +58,9 @@ def test_full_ggn_backpack_reg_integration(reg_Xy, model):
 
 def test_full_ggn_backpack_cls_integration(class_Xy, model):
     X, y = class_Xy
-    backend = BackPackGGN(model, 'classification', stochastic=True)
-    with pytest.raises(ValueError):
-        loss, fggn = backend.full(X, y)
+    # backend = BackPackGGN(model, 'classification', stochastic=True)
+    # with pytest.raises(ValueError):
+    #     loss, fggn = backend.full(X, y)
 
     # cannot test, its implemented based on Jacobians.
     backend = BackPackGGN(model, 'classification', stochastic=False)

--- a/tests/test_curv_backends_backpack.py
+++ b/tests/test_curv_backends_backpack.py
@@ -46,9 +46,6 @@ def reg_Xy():
 
 def test_full_ggn_backpack_reg_integration(reg_Xy, model):
     X, y = reg_Xy
-    # backend = BackPackGGN(model, 'regression', stochastic=True)
-    # with pytest.raises(ValueError):
-    #     loss, fggn = backend.full(X, y)
 
     # cannot test, its implemented based on Jacobians.
     backend = BackPackGGN(model, 'regression', stochastic=False)
@@ -58,10 +55,6 @@ def test_full_ggn_backpack_reg_integration(reg_Xy, model):
 
 def test_full_ggn_backpack_cls_integration(class_Xy, model):
     X, y = class_Xy
-    # backend = BackPackGGN(model, 'classification', stochastic=True)
-    # with pytest.raises(ValueError):
-    #     loss, fggn = backend.full(X, y)
-
     # cannot test, its implemented based on Jacobians.
     backend = BackPackGGN(model, 'classification', stochastic=False)
     loss, H_ggn = backend.full(X, y)

--- a/tests/test_curv_backends_curvlinops.py
+++ b/tests/test_curv_backends_curvlinops.py
@@ -48,62 +48,6 @@ def complex_class_Xy():
     return X, y
 
 
-def test_diag_ggn_cls_curvlinops_against_backpack_full(class_Xy, model):
-    torch.manual_seed(0)
-    np.random.seed(0)
-    X, y = class_Xy
-    backend = CurvlinopsGGN(model, 'classification', stochastic=False)
-    loss, dggn = backend.diag(X[:5], y[:5])
-    loss2, dggn2 = backend.diag(X[5:], y[5:])
-    loss += loss2
-    dggn += dggn2
-
-    # sanity check size of diag ggn
-    assert len(dggn) == model.n_params
-
-    # check against manually computed full GGN:
-    backend = BackPackGGN(model, 'classification', stochastic=False)
-    loss_f, H_ggn = backend.full(X, y)
-    assert torch.allclose(loss, loss_f)
-
-    # Curvlinops can only compute diagonals with MC integration
-    # So, expect approx errors to be high
-    error = torch.linalg.norm(H_ggn.diagonal() - dggn).detach().item()
-    assert error < 0.5
-
-
-def test_diag_ef_cls_curvlinops_against_backpack_full(class_Xy, model):
-    torch.manual_seed(0)
-    np.random.seed(0)
-    X, y = class_Xy
-    backend = CurvlinopsEF(model, 'classification')
-    loss, dggn = backend.diag(X[:5], y[:5])
-    loss2, dggn2 = backend.diag(X[5:], y[5:])
-    loss += loss2
-    dggn += dggn2
-
-    # sanity check size of diag ggn
-    assert len(dggn) == model.n_params
-
-    # check against manually computed full GGN:
-    backend = BackPackEF(model, 'classification')
-    loss_f, H_ggn = backend.full(X, y)
-    assert torch.allclose(loss, loss_f)
-
-    # Curvlinops can only compute diagonals with MC integration
-    # So, expect approx errors to be high
-    error = torch.linalg.norm(H_ggn.diagonal() - dggn).detach().item()
-    assert error < 0.5
-
-
-def test_diag_ggn_stoch_cls_curvlinops(class_Xy, model):
-    X, y = class_Xy
-    backend = CurvlinopsGGN(model, 'classification', stochastic=True)
-    loss, dggn = backend.diag(X, y)
-    # sanity check size of diag ggn
-    assert len(dggn) == model.n_params
-
-
 # def test_kron_ggn_curvlinops_vs_backpack(class_Xy, model):
 #     # For a single data point, Kron is exact and should equal diag GGN
 #     X, y = class_Xy

--- a/tests/test_curv_backends_curvlinops.py
+++ b/tests/test_curv_backends_curvlinops.py
@@ -6,7 +6,12 @@ from torch.nn.utils import parameters_to_vector
 
 from asdfghjkl.operations import Bias, Scale
 
-from laplace.curvature import CurvlinopsGGN, CurvlinopsEF, BackPackGGN, BackPackEF
+from laplace.curvature import CurvlinopsGGN, CurvlinopsEF, CurvlinopsHessian, BackPackGGN, BackPackEF, AsdlHessian, AsdlEF, AsdlGGN
+
+@pytest.fixture(autouse=True)
+def run_around_tests():
+    torch.set_default_dtype(torch.float32)
+    yield
 
 
 @pytest.fixture
@@ -32,7 +37,7 @@ def class_Xy():
 def complex_model():
     torch.manual_seed(711)
     model = torch.nn.Sequential(nn.Conv2d(3, 4, 2, 2), nn.Flatten(), nn.Tanh(),
-                                nn.Linear(16, 20), nn.Tanh(), Scale(), Bias(), nn.Linear(20, 2))
+                                nn.Linear(16, 20), nn.Tanh(), nn.Linear(20, 2))
     setattr(model, 'output_size', 2)
     model_params = list(model.parameters())
     setattr(model, 'n_layers', len(model_params))  # number of parameter groups
@@ -48,133 +53,193 @@ def complex_class_Xy():
     return X, y
 
 
-# def test_kron_ggn_curvlinops_vs_backpack(class_Xy, model):
-#     # For a single data point, Kron is exact and should equal diag GGN
-#     X, y = class_Xy
-#     backend = CurvlinopsGGN(model, 'classification')
-#     loss, kron = backend.kron(X[:1], y[:1], N=1)
-
-#     # check against manually computed full GGN:
-#     backend = BackPackGGN(model, 'classification', stochastic=False)
-#     loss_f, kron_ref = backend.kron(X[:1], y[:1], N=1)
-#     assert torch.allclose(kron.to_matrix(), kron_ref.to_matrix())
+@pytest.fixture
+def reg_Xy():
+    torch.manual_seed(711)
+    X = torch.randn(10, 3)
+    y = torch.randn(10, 2)
+    return X, y
 
 
-# def test_kron_ef_curvlinops_vs_backpack(class_Xy, model):
-#     # For a single data point, Kron is exact and should equal diag GGN
-#     X, y = class_Xy
-#     backend = CurvlinopsEF(model, 'classification')
-#     loss, kron = backend.kron(X[:1], y[:1], N=1)
-#     assert torch.allclose(kron.diag(), dggn)
+def test_full_hess_cls_curvlinops_vs_asdl(class_Xy, model):
+    X, y = class_Xy
+    backend = CurvlinopsHessian(model, 'classification')
+    loss, H = backend.full(X, y)
 
-#     # check against manually computed full GGN:
-#     backend = BackPackGGN(model, 'classification', stochastic=False)
-#     loss_f, H_ggn = backend.full(X, y)
-#     assert torch.allclose(loss, loss_f)
+    backend = AsdlHessian(model, 'classification')
+    loss_ref, H_ref = backend.full(X, y)
 
-
-# @pytest.mark.parametrize('Backend', [AsdlEF, AsdlGGN])
-# def test_kron_batching_correction_kazuki(class_Xy, model, Backend):
-#     X, y = class_Xy
-#     backend = Backend(model, 'classification')
-#     loss, kron = backend.kron(X, y, N=len(X))
-#     assert len(kron.diag()) == model.n_params
-
-#     N = len(X)
-#     M = 3
-#     loss1, kron1 = backend.kron(X[:M], y[:M], N=N)
-#     loss2, kron2 = backend.kron(X[M:], y[M:], N=N)
-#     kron_two = kron1 + kron2
-#     loss_two = loss1 + loss2
-#     assert torch.allclose(kron.diag(), kron_two.diag())
-#     assert torch.allclose(loss, loss_two)
+    assert torch.allclose(loss, loss_ref)
+    assert torch.allclose(H, H_ref)
 
 
-# @pytest.mark.parametrize('Backend', [AsdlGGN, AsdlEF])
-# def test_kron_summing_up_vs_diag_kazuki(class_Xy, model, Backend):
-#     # For a single data point, Kron is exact and should equal diag class_Xy
-#     X, y = class_Xy
-#     backend = Backend(model, 'classification')
-#     loss, dggn = backend.diag(X, y, N=len(X))
-#     loss, kron = backend.kron(X, y, N=len(X))
-#     assert torch.allclose(kron.diag().norm(), dggn.norm(), rtol=1e-1)
+def test_full_hess_reg_curvlinops_vs_asdl(reg_Xy, model):
+    X, y = reg_Xy
+    backend = CurvlinopsHessian(model, 'regression')
+    loss, H = backend.full(X, y)
+
+    backend = AsdlHessian(model, 'regression')
+    loss_ref, H_ref = backend.full(X, y)
+
+    assert torch.allclose(loss, loss_ref)
+    assert torch.allclose(H, H_ref, atol=1e-6)
 
 
-# def test_complex_diag_ggn_stoch_cls_kazuki(complex_class_Xy, complex_model):
-#     X, y = complex_class_Xy
-#     backend = AsdlGGN(complex_model, 'classification', stochastic=True)
-#     loss, dggn = backend.diag(X, y)
-#     # sanity check size of diag ggn
-#     assert len(dggn) == complex_model.n_params
+def test_kron_ggn_cls_curvlinops_vs_backpack(class_Xy, model):
+    X, y = class_Xy
+    print(X.dtype, y.dtype);
+    backend = CurvlinopsGGN(model, 'classification', stochastic=False)
+    loss, kron = backend.kron(X, y, N=1)
 
-#     # same order of magnitude os non-stochastic.
-#     loss_ns, dggn_ns = backend.diag(X, y)
-#     assert loss_ns == loss
-#     assert torch.allclose(dggn, dggn_ns, atol=1e-8, rtol=1)
+    backend = BackPackGGN(model, 'classification', stochastic=False)
+    loss_ref, kron_ref = backend.kron(X, y, N=1)
 
-
-# @pytest.mark.parametrize('Backend', [AsdlEF, AsdlGGN])
-# def test_complex_kron_kazuki_vs_diag_kazuki(complex_class_Xy, complex_model, Backend):
-#     # For a single data point, Kron is exact and should equal diag GGN
-#     X, y = complex_class_Xy
-#     backend = Backend(complex_model, 'classification')
-#     loss, dggn = backend.diag(X[:1], y[:1], N=1)
-#     # sanity check size of diag ggn
-#     assert len(dggn) == complex_model.n_params
-#     loss, kron = backend.kron(X[:1], y[:1], N=1)
-#     assert torch.allclose(kron.diag().norm(), dggn.norm(), rtol=1e-1)
+    assert torch.allclose(loss, loss_ref)
+    assert torch.allclose(kron.to_matrix(), kron_ref.to_matrix())
 
 
-# @pytest.mark.parametrize('Backend', [AsdlEF, AsdlGGN])
-# def test_complex_kron_batching_correction_kazuki(complex_class_Xy, complex_model, Backend):
-#     X, y = complex_class_Xy
-#     backend = Backend(complex_model, 'classification')
-#     loss, kron = backend.kron(X, y, N=len(X))
-#     assert len(kron.diag()) == complex_model.n_params
+def test_kron_ggn_reg_curvlinops_vs_backpack(reg_Xy, model):
+    X, y = reg_Xy
+    backend = CurvlinopsGGN(model, 'regression', stochastic=False)
+    loss, kron = backend.kron(X, y, N=1)
 
-#     N = len(X)
-#     M = 3
-#     loss1, kron1 = backend.kron(X[:M], y[:M], N=N)
-#     loss2, kron2 = backend.kron(X[M:], y[M:], N=N)
-#     kron_two = kron1 + kron2
-#     loss_two = loss1 + loss2
-#     assert torch.allclose(kron.diag(), kron_two.diag())
-#     assert torch.allclose(loss, loss_two)
+    backend = BackPackGGN(model, 'regression', stochastic=False)
+    loss_ref, kron_ref = backend.kron(X, y, N=1)
+
+    assert torch.allclose(loss, loss_ref)
+    assert torch.allclose(kron.to_matrix(), kron_ref.to_matrix())
 
 
-# @pytest.mark.parametrize('Backend', [AsdlGGN, AsdlEF])
-# def test_complex_kron_summing_up_vs_diag_class_kazuki(complex_class_Xy, complex_model, Backend):
-#     # For a single data point, Kron is exact and should equal diag class_Xy
-#     X, y = complex_class_Xy
-#     backend = Backend(complex_model, 'classification')
-#     loss, dggn = backend.diag(X, y, N=len(X))
-#     loss, kron = backend.kron(X, y, N=len(X))
-#     assert torch.allclose(kron.diag().norm(), dggn.norm(), rtol=1e-2)
+def test_kron_ef_cls_curvlinops_vs_backpack(class_Xy, model):
+    X, y = class_Xy
+    backend = CurvlinopsEF(model, 'classification')
+    loss, kron = backend.kron(X, y, N=1)
+
+    backend = AsdlEF(model, 'classification')
+    loss_ref, kron_ref = backend.kron(X, y, N=1)
+
+    assert torch.allclose(loss, loss_ref)
+    assert torch.allclose(kron.to_matrix(), kron_ref.to_matrix())
 
 
-# def test_kron_normalization_ggn_class(class_Xy, model):
-#     X, y = class_Xy
-#     xi, yi = X[:1], y[:1]
-#     backend = AsdlGGN(model, 'classification', stochastic=False)
-#     loss, kron = backend.kron(xi, yi, N=1)
-#     kron_true = 7 * kron
-#     loss_true = 7 * loss
-#     X = torch.repeat_interleave(xi, 7, 0)
-#     y = torch.repeat_interleave(yi, 7, 0)
-#     loss_test, kron_test  = backend.kron(X, y, N=7)
-#     assert torch.allclose(kron_true.diag(), kron_test.diag())
-#     assert torch.allclose(loss_true, loss_test)
+@pytest.mark.parametrize('Backend', [CurvlinopsEF, CurvlinopsGGN])
+def test_kron_batching_correction_cls_curvlinops(class_Xy, model, Backend):
+    X, y = class_Xy
+    backend = Backend(model, 'classification')
+    loss, kron = backend.kron(X, y, N=len(X))
+    assert len(kron.diag()) == model.n_params
+
+    N = len(X)
+    M = 3
+    loss1, kron1 = backend.kron(X[:M], y[:M], N=N)
+    loss2, kron2 = backend.kron(X[M:], y[M:], N=N)
+    kron_two = kron1 + kron2
+    loss_two = loss1 + loss2
+    assert torch.allclose(kron.diag(), kron_two.diag())
+    assert torch.allclose(loss, loss_two)
 
 
-# def test_kron_normalization_ef_class(class_Xy, model):
-#     X, y = class_Xy
-#     xi, yi = X[:1], y[:1]
-#     backend = AsdlEF(model, 'classification')
-#     loss, kron = backend.kron(xi, yi, N=1)
-#     kron_true = 7 * kron
-#     loss_true = 7 * loss
-#     X = torch.repeat_interleave(xi, 7, 0)
-#     y = torch.repeat_interleave(yi, 7, 0)
-#     loss_test, kron_test  = backend.kron(X, y, N=7)
-#     assert torch.allclose(kron_true.diag(), kron_test.diag())
-#     assert torch.allclose(loss_true, loss_test)
+@pytest.mark.parametrize('Backend', [CurvlinopsEF, CurvlinopsGGN])
+def test_kron_batching_correction_reg_curvlinops(reg_Xy, model, Backend):
+    X, y = reg_Xy
+    backend = Backend(model, 'regression')
+    loss, kron = backend.kron(X, y, N=len(X))
+    assert len(kron.diag()) == model.n_params
+
+    N = len(X)
+    M = 3
+    loss1, kron1 = backend.kron(X[:M], y[:M], N=N)
+    loss2, kron2 = backend.kron(X[M:], y[M:], N=N)
+    kron_two = kron1 + kron2
+    loss_two = loss1 + loss2
+    assert torch.allclose(kron.diag(), kron_two.diag())
+    assert torch.allclose(loss, loss_two)
+
+
+@pytest.mark.parametrize('Backend', [CurvlinopsEF, CurvlinopsGGN])
+def test_kron_summing_up_vs_diag_cls_curvlinops(class_Xy, model, Backend):
+    X, y = class_Xy
+    backend = Backend(model, 'classification')
+    loss, dggn = backend.diag(X, y, N=len(X))
+    loss, kron = backend.kron(X, y, N=len(X))
+    assert torch.allclose(kron.diag().norm(), dggn.norm(), rtol=1e-1)
+
+
+def test_complex_diag_ggn_stoch_cls_curvlinops(complex_class_Xy, complex_model):
+    X, y = complex_class_Xy
+    backend = CurvlinopsGGN(complex_model, 'classification', stochastic=True)
+    loss, dggn = backend.diag(X, y)
+    # sanity check size of diag ggn
+    assert len(dggn) == complex_model.n_params
+
+    # same order of magnitude os non-stochastic.
+    loss_ns, dggn_ns = backend.diag(X, y)
+    assert loss_ns == loss
+    assert torch.allclose(dggn, dggn_ns, atol=1e-8, rtol=1)
+
+
+@pytest.mark.parametrize('Backend', [CurvlinopsEF, CurvlinopsGGN])
+def test_complex_kron_curvlinops_vs_diag_curvlinops(complex_class_Xy, complex_model, Backend):
+    # For a single data point, Kron is exact and should equal diag GGN
+    X, y = complex_class_Xy
+    backend = Backend(complex_model, 'classification')
+    loss, dggn = backend.diag(X[:1], y[:1], N=1)
+    # sanity check size of diag ggn
+    assert len(dggn) == complex_model.n_params
+    loss, kron = backend.kron(X[:1], y[:1], N=1)
+    assert torch.allclose(kron.diag().norm(), dggn.norm(), rtol=1e-1)
+
+
+@pytest.mark.parametrize('Backend', [CurvlinopsEF, CurvlinopsGGN])
+def test_complex_kron_batching_correction_curvlinops(complex_class_Xy, complex_model, Backend):
+    X, y = complex_class_Xy
+    backend = Backend(complex_model, 'classification')
+    loss, kron = backend.kron(X, y, N=len(X))
+    assert len(kron.diag()) == complex_model.n_params
+
+    N = len(X)
+    M = 3
+    loss1, kron1 = backend.kron(X[:M], y[:M], N=N)
+    loss2, kron2 = backend.kron(X[M:], y[M:], N=N)
+    kron_two = kron1 + kron2
+    loss_two = loss1 + loss2
+    assert torch.allclose(kron.diag(), kron_two.diag())
+    assert torch.allclose(loss, loss_two)
+
+
+@pytest.mark.parametrize('Backend', [CurvlinopsEF, CurvlinopsGGN])
+def test_complex_kron_summing_up_vs_diag_class_curvlinops(complex_class_Xy, complex_model, Backend):
+    # For a single data point, Kron is exact and should equal diag class_Xy
+    X, y = complex_class_Xy
+    backend = Backend(complex_model, 'classification')
+    loss, dggn = backend.diag(X, y, N=len(X))
+    loss, kron = backend.kron(X, y, N=len(X))
+    assert torch.allclose(kron.diag().norm(), dggn.norm(), rtol=1e-2)
+
+
+def test_kron_normalization_ggn_class(class_Xy, model):
+    X, y = class_Xy
+    xi, yi = X[:1], y[:1]
+    backend = CurvlinopsGGN(model, 'classification', stochastic=False)
+    loss, kron = backend.kron(xi, yi, N=1)
+    kron_true = 7 * kron
+    loss_true = 7 * loss
+    X = torch.repeat_interleave(xi, 7, 0)
+    y = torch.repeat_interleave(yi, 7, 0)
+    loss_test, kron_test  = backend.kron(X, y, N=7)
+    assert torch.allclose(kron_true.diag(), kron_test.diag())
+    assert torch.allclose(loss_true, loss_test)
+
+
+def test_kron_normalization_ef_class(class_Xy, model):
+    X, y = class_Xy
+    xi, yi = X[:1], y[:1]
+    backend = CurvlinopsEF(model, 'classification')
+    loss, kron = backend.kron(xi, yi, N=1)
+    kron_true = 7 * kron
+    loss_true = 7 * loss
+    X = torch.repeat_interleave(xi, 7, 0)
+    y = torch.repeat_interleave(yi, 7, 0)
+    loss_test, kron_test  = backend.kron(X, y, N=7)
+    assert torch.allclose(kron_true.diag(), kron_test.diag())
+    assert torch.allclose(loss_true, loss_test)

--- a/tests/test_curv_backends_curvlinops.py
+++ b/tests/test_curv_backends_curvlinops.py
@@ -94,6 +94,7 @@ def test_full_ggn_curvlinops_vs_asdl(class_Xy, model):
 
 
 def test_full_ggn_stochastic(class_Xy, model):
+    torch.manual_seed(123)
     X, y = class_Xy
 
     backend = CurvlinopsGGN(model, 'classification', stochastic=True)

--- a/tests/test_curv_backends_curvlinops.py
+++ b/tests/test_curv_backends_curvlinops.py
@@ -89,8 +89,8 @@ def test_full_ggn_curvlinops_vs_asdl(class_Xy, model):
     backend = AsdlGGN(model, 'classification', stochastic=False)
     loss_ref, H_ref = backend.full(X, y)
 
-    assert torch.allclose(loss, loss_ref)
-    assert torch.allclose(H, H_ref)
+    assert torch.allclose(loss, loss_ref, rtol=1e-4)
+    assert torch.allclose(H, H_ref, rtol=1e-4)
 
 
 def test_full_ggn_stochastic(class_Xy, model):
@@ -122,8 +122,8 @@ def test_full_ef_curvlinops_vs_asdl(class_Xy, model):
     backend = AsdlEF(model, 'classification')
     loss_ref, H_ref = backend.full(X, y)
 
-    assert torch.allclose(loss, loss_ref)
-    assert torch.allclose(H, H_ref)
+    assert torch.allclose(loss, loss_ref, rtol=1e-4)
+    assert torch.allclose(H, H_ref, rtol=1e-4)
 
 
 @pytest.mark.parametrize('loss_type', ['classification', 'regression'])

--- a/tests/test_curv_backends_curvlinops.py
+++ b/tests/test_curv_backends_curvlinops.py
@@ -1,0 +1,236 @@
+import pytest
+import numpy as np
+import torch
+from torch import nn
+from torch.nn.utils import parameters_to_vector
+
+from asdfghjkl.operations import Bias, Scale
+
+from laplace.curvature import CurvlinopsGGN, CurvlinopsEF, BackPackGGN, BackPackEF
+
+
+@pytest.fixture
+def model():
+    torch.manual_seed(711)
+    model = torch.nn.Sequential(nn.Linear(3, 20), nn.Tanh(), nn.Linear(20, 2))
+    setattr(model, 'output_size', 2)
+    model_params = list(model.parameters())
+    setattr(model, 'n_layers', len(model_params))  # number of parameter groups
+    setattr(model, 'n_params', len(parameters_to_vector(model_params)))
+    return model
+
+
+@pytest.fixture
+def class_Xy():
+    torch.manual_seed(711)
+    X = torch.randn(10, 3)
+    y = torch.randint(2, (10,))
+    return X, y
+
+
+@pytest.fixture
+def complex_model():
+    torch.manual_seed(711)
+    model = torch.nn.Sequential(nn.Conv2d(3, 4, 2, 2), nn.Flatten(), nn.Tanh(),
+                                nn.Linear(16, 20), nn.Tanh(), Scale(), Bias(), nn.Linear(20, 2))
+    setattr(model, 'output_size', 2)
+    model_params = list(model.parameters())
+    setattr(model, 'n_layers', len(model_params))  # number of parameter groups
+    setattr(model, 'n_params', len(parameters_to_vector(model_params)))
+    return model
+
+
+@pytest.fixture
+def complex_class_Xy():
+    torch.manual_seed(711)
+    X = torch.randn(10, 3, 5, 5)
+    y = torch.randint(2, (10,))
+    return X, y
+
+
+def test_diag_ggn_cls_curvlinops_against_backpack_full(class_Xy, model):
+    torch.manual_seed(0)
+    np.random.seed(0)
+    X, y = class_Xy
+    backend = CurvlinopsGGN(model, 'classification', stochastic=False)
+    loss, dggn = backend.diag(X[:5], y[:5])
+    loss2, dggn2 = backend.diag(X[5:], y[5:])
+    loss += loss2
+    dggn += dggn2
+
+    # sanity check size of diag ggn
+    assert len(dggn) == model.n_params
+
+    # check against manually computed full GGN:
+    backend = BackPackGGN(model, 'classification', stochastic=False)
+    loss_f, H_ggn = backend.full(X, y)
+    assert torch.allclose(loss, loss_f)
+
+    # Curvlinops can only compute diagonals with MC integration
+    # So, expect approx errors to be high
+    error = torch.linalg.norm(H_ggn.diagonal() - dggn).detach().item()
+    assert error < 0.5
+
+
+def test_diag_ef_cls_curvlinops_against_backpack_full(class_Xy, model):
+    torch.manual_seed(0)
+    np.random.seed(0)
+    X, y = class_Xy
+    backend = CurvlinopsEF(model, 'classification')
+    loss, dggn = backend.diag(X[:5], y[:5])
+    loss2, dggn2 = backend.diag(X[5:], y[5:])
+    loss += loss2
+    dggn += dggn2
+
+    # sanity check size of diag ggn
+    assert len(dggn) == model.n_params
+
+    # check against manually computed full GGN:
+    backend = BackPackEF(model, 'classification')
+    loss_f, H_ggn = backend.full(X, y)
+    assert torch.allclose(loss, loss_f)
+
+    # Curvlinops can only compute diagonals with MC integration
+    # So, expect approx errors to be high
+    error = torch.linalg.norm(H_ggn.diagonal() - dggn).detach().item()
+    assert error < 0.5
+
+
+def test_diag_ggn_stoch_cls_curvlinops(class_Xy, model):
+    X, y = class_Xy
+    backend = CurvlinopsGGN(model, 'classification', stochastic=True)
+    loss, dggn = backend.diag(X, y)
+    # sanity check size of diag ggn
+    assert len(dggn) == model.n_params
+
+
+# def test_kron_ggn_curvlinops_vs_backpack(class_Xy, model):
+#     # For a single data point, Kron is exact and should equal diag GGN
+#     X, y = class_Xy
+#     backend = CurvlinopsGGN(model, 'classification')
+#     loss, kron = backend.kron(X[:1], y[:1], N=1)
+
+#     # check against manually computed full GGN:
+#     backend = BackPackGGN(model, 'classification', stochastic=False)
+#     loss_f, kron_ref = backend.kron(X[:1], y[:1], N=1)
+#     assert torch.allclose(kron.to_matrix(), kron_ref.to_matrix())
+
+
+# def test_kron_ef_curvlinops_vs_backpack(class_Xy, model):
+#     # For a single data point, Kron is exact and should equal diag GGN
+#     X, y = class_Xy
+#     backend = CurvlinopsEF(model, 'classification')
+#     loss, kron = backend.kron(X[:1], y[:1], N=1)
+#     assert torch.allclose(kron.diag(), dggn)
+
+#     # check against manually computed full GGN:
+#     backend = BackPackGGN(model, 'classification', stochastic=False)
+#     loss_f, H_ggn = backend.full(X, y)
+#     assert torch.allclose(loss, loss_f)
+
+
+# @pytest.mark.parametrize('Backend', [AsdlEF, AsdlGGN])
+# def test_kron_batching_correction_kazuki(class_Xy, model, Backend):
+#     X, y = class_Xy
+#     backend = Backend(model, 'classification')
+#     loss, kron = backend.kron(X, y, N=len(X))
+#     assert len(kron.diag()) == model.n_params
+
+#     N = len(X)
+#     M = 3
+#     loss1, kron1 = backend.kron(X[:M], y[:M], N=N)
+#     loss2, kron2 = backend.kron(X[M:], y[M:], N=N)
+#     kron_two = kron1 + kron2
+#     loss_two = loss1 + loss2
+#     assert torch.allclose(kron.diag(), kron_two.diag())
+#     assert torch.allclose(loss, loss_two)
+
+
+# @pytest.mark.parametrize('Backend', [AsdlGGN, AsdlEF])
+# def test_kron_summing_up_vs_diag_kazuki(class_Xy, model, Backend):
+#     # For a single data point, Kron is exact and should equal diag class_Xy
+#     X, y = class_Xy
+#     backend = Backend(model, 'classification')
+#     loss, dggn = backend.diag(X, y, N=len(X))
+#     loss, kron = backend.kron(X, y, N=len(X))
+#     assert torch.allclose(kron.diag().norm(), dggn.norm(), rtol=1e-1)
+
+
+# def test_complex_diag_ggn_stoch_cls_kazuki(complex_class_Xy, complex_model):
+#     X, y = complex_class_Xy
+#     backend = AsdlGGN(complex_model, 'classification', stochastic=True)
+#     loss, dggn = backend.diag(X, y)
+#     # sanity check size of diag ggn
+#     assert len(dggn) == complex_model.n_params
+
+#     # same order of magnitude os non-stochastic.
+#     loss_ns, dggn_ns = backend.diag(X, y)
+#     assert loss_ns == loss
+#     assert torch.allclose(dggn, dggn_ns, atol=1e-8, rtol=1)
+
+
+# @pytest.mark.parametrize('Backend', [AsdlEF, AsdlGGN])
+# def test_complex_kron_kazuki_vs_diag_kazuki(complex_class_Xy, complex_model, Backend):
+#     # For a single data point, Kron is exact and should equal diag GGN
+#     X, y = complex_class_Xy
+#     backend = Backend(complex_model, 'classification')
+#     loss, dggn = backend.diag(X[:1], y[:1], N=1)
+#     # sanity check size of diag ggn
+#     assert len(dggn) == complex_model.n_params
+#     loss, kron = backend.kron(X[:1], y[:1], N=1)
+#     assert torch.allclose(kron.diag().norm(), dggn.norm(), rtol=1e-1)
+
+
+# @pytest.mark.parametrize('Backend', [AsdlEF, AsdlGGN])
+# def test_complex_kron_batching_correction_kazuki(complex_class_Xy, complex_model, Backend):
+#     X, y = complex_class_Xy
+#     backend = Backend(complex_model, 'classification')
+#     loss, kron = backend.kron(X, y, N=len(X))
+#     assert len(kron.diag()) == complex_model.n_params
+
+#     N = len(X)
+#     M = 3
+#     loss1, kron1 = backend.kron(X[:M], y[:M], N=N)
+#     loss2, kron2 = backend.kron(X[M:], y[M:], N=N)
+#     kron_two = kron1 + kron2
+#     loss_two = loss1 + loss2
+#     assert torch.allclose(kron.diag(), kron_two.diag())
+#     assert torch.allclose(loss, loss_two)
+
+
+# @pytest.mark.parametrize('Backend', [AsdlGGN, AsdlEF])
+# def test_complex_kron_summing_up_vs_diag_class_kazuki(complex_class_Xy, complex_model, Backend):
+#     # For a single data point, Kron is exact and should equal diag class_Xy
+#     X, y = complex_class_Xy
+#     backend = Backend(complex_model, 'classification')
+#     loss, dggn = backend.diag(X, y, N=len(X))
+#     loss, kron = backend.kron(X, y, N=len(X))
+#     assert torch.allclose(kron.diag().norm(), dggn.norm(), rtol=1e-2)
+
+
+# def test_kron_normalization_ggn_class(class_Xy, model):
+#     X, y = class_Xy
+#     xi, yi = X[:1], y[:1]
+#     backend = AsdlGGN(model, 'classification', stochastic=False)
+#     loss, kron = backend.kron(xi, yi, N=1)
+#     kron_true = 7 * kron
+#     loss_true = 7 * loss
+#     X = torch.repeat_interleave(xi, 7, 0)
+#     y = torch.repeat_interleave(yi, 7, 0)
+#     loss_test, kron_test  = backend.kron(X, y, N=7)
+#     assert torch.allclose(kron_true.diag(), kron_test.diag())
+#     assert torch.allclose(loss_true, loss_test)
+
+
+# def test_kron_normalization_ef_class(class_Xy, model):
+#     X, y = class_Xy
+#     xi, yi = X[:1], y[:1]
+#     backend = AsdlEF(model, 'classification')
+#     loss, kron = backend.kron(xi, yi, N=1)
+#     kron_true = 7 * kron
+#     loss_true = 7 * loss
+#     X = torch.repeat_interleave(xi, 7, 0)
+#     y = torch.repeat_interleave(yi, 7, 0)
+#     loss_test, kron_test  = backend.kron(X, y, N=7)
+#     assert torch.allclose(kron_true.diag(), kron_test.diag())
+#     assert torch.allclose(loss_true, loss_test)

--- a/tests/test_curv_backends_interface.py
+++ b/tests/test_curv_backends_interface.py
@@ -6,7 +6,7 @@ from torch.nn.utils import parameters_to_vector
 
 from asdfghjkl.operations import Bias, Scale
 
-from laplace.curvature import CurvlinopsGGN, CurvlinopsEF, BackPackGGN, BackPackEF, GGNInterface, EFInterface
+from laplace.curvature import CurvlinopsGGN, CurvlinopsEF, BackPackGGN, BackPackEF, GGNInterface, EFInterface, AsdlGGN, AsdlEF, CurvatureInterface
 
 
 @pytest.fixture
@@ -35,6 +35,7 @@ def reg_Xy():
     y = torch.randn(10, 2)
     return X, y
 
+
 @pytest.fixture
 def complex_model():
     torch.manual_seed(711)
@@ -55,6 +56,39 @@ def complex_class_Xy():
     return X, y
 
 
+def test_batchgrad_cls(class_Xy, model):
+    X, y = class_Xy
+    backend = CurvatureInterface(model, 'classification')
+    batchgrads, loss = backend.gradients(X, y)
+
+    backend_asdl = AsdlEF(model, 'classification')
+    batchgrads_ref, loss_ref = backend_asdl.gradients(X, y)
+
+    torch.allclose(batchgrads, batchgrads_ref)
+
+
+def test_batchgrad_cls_complex(complex_class_Xy, complex_model):
+    X, y = complex_class_Xy
+    backend = CurvatureInterface(complex_model, 'classification')
+    batchgrads, loss = backend.gradients(X, y)
+
+    backend_asdl = AsdlEF(complex_model, 'classification')
+    batchgrads_ref, loss_ref = backend_asdl.gradients(X, y)
+
+    torch.allclose(batchgrads, batchgrads_ref)
+
+
+def test_batchgrad_reg(reg_Xy, model):
+    X, y = reg_Xy
+    backend = CurvatureInterface(model, 'regression')
+    batchgrads, loss = backend.gradients(X, y)
+
+    backend_asdl = BackPackEF(model, 'regression')
+    batchgrads_ref, loss_ref = backend_asdl.gradients(X, y)
+
+    torch.allclose(batchgrads, batchgrads_ref)
+
+
 def test_diag_ggn_cls_curvlinops_against_backpack_full(class_Xy, model):
     torch.manual_seed(0)
     np.random.seed(0)
@@ -73,6 +107,27 @@ def test_diag_ggn_cls_curvlinops_against_backpack_full(class_Xy, model):
     loss_f, H_ggn = backend.full(X, y)
     assert torch.allclose(loss, loss_f)
     assert torch.allclose(dggn, H_ggn.diag())
+
+
+def test_diag_ggn_complex_cls_curvlinops_against_backpack_full(complex_class_Xy, complex_model):
+    torch.manual_seed(0)
+    np.random.seed(0)
+    X, y = complex_class_Xy
+    backend = GGNInterface(complex_model, 'classification', stochastic=False)
+    loss, dggn = backend.diag(X[:5], y[:5])
+    loss2, dggn2 = backend.diag(X[5:], y[5:])
+    loss += loss2
+    dggn += dggn2
+
+    # sanity check size of diag ggn
+    assert len(dggn) == complex_model.n_params
+
+    # check against manually computed full GGN:
+    backend = AsdlGGN(complex_model, 'classification', stochastic=False)
+    loss_f, H_ggn = backend.full(X, y)
+    assert torch.allclose(loss, loss_f)
+    assert torch.allclose(dggn, H_ggn.diag())
+
 
 def test_diag_ggn_stoch_cls_curvlinops_against_backpack_full(class_Xy, model):
     torch.manual_seed(0)
@@ -113,6 +168,7 @@ def test_diag_ef_cls_curvlinops_against_backpack_full(class_Xy, model):
     assert torch.allclose(loss, loss_f)
     assert torch.allclose(dggn, H_ggn.diag())
 
+
 def test_diag_ggn_reg_curvlinops_against_backpack_full(reg_Xy, model):
     torch.manual_seed(0)
     np.random.seed(0)
@@ -131,6 +187,7 @@ def test_diag_ggn_reg_curvlinops_against_backpack_full(reg_Xy, model):
     loss_f, H_ggn = backend.full(X, y)
     assert torch.allclose(loss, loss_f)
     assert torch.allclose(dggn, H_ggn.diag())
+
 
 def test_diag_ggn_stoch_reg_curvlinops_against_backpack_full(reg_Xy, model):
     torch.manual_seed(0)
@@ -290,5 +347,4 @@ def test_full_ef_reg_curvlinops_against_backpack_full(reg_Xy, model):
     loss_f, H_ggn = backend.full(X, y)
     assert torch.allclose(loss, loss_f)
     assert torch.allclose(fggn, H_ggn, atol=0.0001)
-
 

--- a/tests/test_jacobians.py
+++ b/tests/test_jacobians.py
@@ -2,7 +2,7 @@ import pytest
 import torch
 from torch import nn
 
-from laplace.curvature import AsdlInterface, BackPackInterface
+from laplace.curvature import AsdlInterface, BackPackInterface, CurvatureInterface
 from laplace.utils import FeatureExtractor
 from tests.utils import jacobians_naive
 
@@ -34,7 +34,7 @@ def X():
     return torch.randn(200, 3)
 
 
-@pytest.mark.parametrize('backend_cls', [AsdlInterface, BackPackInterface])
+@pytest.mark.parametrize('backend_cls', [CurvatureInterface, AsdlInterface, BackPackInterface])
 def test_linear_jacobians(linear_model, X, backend_cls):
     # jacobian of linear model is input X.
     backend = backend_cls(linear_model, 'classification')
@@ -46,7 +46,7 @@ def test_linear_jacobians(linear_model, X, backend_cls):
     assert torch.allclose(f, linear_model(X), atol=1e-5)
 
 
-@pytest.mark.parametrize('backend_cls', [AsdlInterface, BackPackInterface])
+@pytest.mark.parametrize('backend_cls', [CurvatureInterface, AsdlInterface, BackPackInterface])
 def test_jacobians_singleoutput(singleoutput_model, X, backend_cls):
     model = singleoutput_model
     backend = backend_cls(model, 'classification')
@@ -58,7 +58,7 @@ def test_jacobians_singleoutput(singleoutput_model, X, backend_cls):
     assert torch.allclose(f, f_naive)
 
 
-@pytest.mark.parametrize('backend_cls', [AsdlInterface, BackPackInterface])
+@pytest.mark.parametrize('backend_cls', [CurvatureInterface, AsdlInterface, BackPackInterface])
 def test_jacobians_multioutput(multioutput_model, X, backend_cls):
     model = multioutput_model
     backend = backend_cls(model, 'classification')
@@ -70,7 +70,7 @@ def test_jacobians_multioutput(multioutput_model, X, backend_cls):
     assert torch.allclose(f, f_naive)
 
 
-@pytest.mark.parametrize('backend_cls', [AsdlInterface, BackPackInterface])
+@pytest.mark.parametrize('backend_cls', [CurvatureInterface, AsdlInterface, BackPackInterface])
 def test_last_layer_jacobians_singleoutput(singleoutput_model, X, backend_cls):
     model = FeatureExtractor(singleoutput_model)
     backend = backend_cls(model, 'classification')
@@ -83,7 +83,7 @@ def test_last_layer_jacobians_singleoutput(singleoutput_model, X, backend_cls):
     assert torch.allclose(f, f_naive)
 
 
-@pytest.mark.parametrize('backend_cls', [AsdlInterface, BackPackInterface])
+@pytest.mark.parametrize('backend_cls', [CurvatureInterface, AsdlInterface, BackPackInterface])
 def test_last_layer_jacobians_multioutput(multioutput_model, X, backend_cls):
     model = FeatureExtractor(multioutput_model)
     backend = backend_cls(model, 'classification')
@@ -96,7 +96,7 @@ def test_last_layer_jacobians_multioutput(multioutput_model, X, backend_cls):
     assert torch.allclose(f, f_naive)
 
 
-@pytest.mark.parametrize('backend_cls', [BackPackInterface])
+@pytest.mark.parametrize('backend_cls', [CurvatureInterface, BackPackInterface])
 def test_backprop_jacobians_singleoutput(singleoutput_model, X, backend_cls):
     X.requires_grad = True
     backend = backend_cls(singleoutput_model, 'regression')
@@ -114,7 +114,7 @@ def test_backprop_jacobians_singleoutput(singleoutput_model, X, backend_cls):
         assert False
 
 
-@pytest.mark.parametrize('backend_cls', [BackPackInterface])
+@pytest.mark.parametrize('backend_cls', [CurvatureInterface, BackPackInterface])
 def test_backprop_jacobians_multioutput(multioutput_model, X, backend_cls):
     X.requires_grad = True
     backend = backend_cls(multioutput_model, 'regression')
@@ -133,7 +133,7 @@ def test_backprop_jacobians_multioutput(multioutput_model, X, backend_cls):
         assert False
 
 
-@pytest.mark.parametrize('backend_cls', [BackPackInterface])
+@pytest.mark.parametrize('backend_cls', [CurvatureInterface, BackPackInterface])
 def test_backprop_last_layer_jacobians_singleoutput(singleoutput_model, X, backend_cls):
     X.requires_grad = True
     backend = backend_cls(
@@ -153,7 +153,7 @@ def test_backprop_last_layer_jacobians_singleoutput(singleoutput_model, X, backe
         assert False
 
 
-@pytest.mark.parametrize('backend_cls', [BackPackInterface])
+@pytest.mark.parametrize('backend_cls', [CurvatureInterface, BackPackInterface])
 def test_backprop_last_layer_jacobians_multioutput(multioutput_model, X, backend_cls):
     X.requires_grad = True
     backend = backend_cls(

--- a/tests/test_lllaplace.py
+++ b/tests/test_lllaplace.py
@@ -12,9 +12,11 @@ from laplace.lllaplace import FullLLLaplace, KronLLLaplace, DiagLLLaplace
 from laplace.utils import FeatureExtractor
 from tests.utils import jacobians_naive
 
+@pytest.fixture(autouse=True)
+def run_around_tests():
+    torch.set_default_dtype(torch.float64)
+    yield
 
-torch.manual_seed(240)
-torch.set_default_tensor_type(torch.DoubleTensor)
 flavors = [FullLLLaplace, KronLLLaplace, DiagLLLaplace]
 
 
@@ -424,7 +426,7 @@ def test_backprop_glm(laplace, model, reg_loader):
 
     try:
         grad_X_mu = torch.autograd.grad(f_mu.sum(), X, retain_graph=True)[0]
-        grad_X_var = torch.autograd.grad(f_var.sum(), X)[0] 
+        grad_X_var = torch.autograd.grad(f_var.sum(), X)[0]
 
         assert grad_X_mu.shape == X.shape
         assert grad_X_var.shape == X.shape
@@ -443,7 +445,7 @@ def test_backprop_glm_joint(laplace, model, reg_loader):
 
     try:
         grad_X_mu = torch.autograd.grad(f_mu.sum(), X, retain_graph=True)[0]
-        grad_X_var = torch.autograd.grad(f_cov.sum(), X)[0] 
+        grad_X_var = torch.autograd.grad(f_cov.sum(), X)[0]
 
         assert grad_X_mu.shape == X.shape
         assert grad_X_var.shape == X.shape
@@ -462,7 +464,7 @@ def test_backprop_glm_mc(laplace, model, reg_loader):
 
     try:
         grad_X_mu = torch.autograd.grad(f_mu.sum(), X, retain_graph=True)[0]
-        grad_X_var = torch.autograd.grad(f_var.sum(), X)[0] 
+        grad_X_var = torch.autograd.grad(f_var.sum(), X)[0]
 
         assert grad_X_mu.shape == X.shape
         assert grad_X_var.shape == X.shape
@@ -481,7 +483,7 @@ def test_backprop_nn(laplace, model, reg_loader):
 
     try:
         grad_X_mu = torch.autograd.grad(f_mu.sum(), X, retain_graph=True)[0]
-        grad_X_var = torch.autograd.grad(f_var.sum(), X)[0] 
+        grad_X_var = torch.autograd.grad(f_var.sum(), X)[0]
 
         assert grad_X_mu.shape == X.shape
         assert grad_X_var.shape == X.shape

--- a/tests/test_subnetlaplace.py
+++ b/tests/test_subnetlaplace.py
@@ -224,7 +224,7 @@ def test_score_based_subnet_masks(model, likelihood, subnetwork_mask, class_load
     model_params = parameters_to_vector(model.parameters())
 
     # set subnetwork mask arguments
-    if subnetwork_mask == LargestVarianceDiagLaplaceSubnetMask: 
+    if subnetwork_mask == LargestVarianceDiagLaplaceSubnetMask:
         diag_laplace_model = DiagLaplace(model, likelihood)
         subnetmask_kwargs = dict(model=model, diag_laplace_model=diag_laplace_model)
     elif subnetwork_mask == LargestVarianceSWAGSubnetMask:
@@ -324,7 +324,7 @@ def test_layer_subnet_masks(model, likelihood, subnetwork_mask, class_loader, re
             subnetmask = subnetwork_mask(**subnetmask_kwargs)
             subnetmask.select(loader)
 
-        # define last-layer Laplace model by parameter names and check that 
+        # define last-layer Laplace model by parameter names and check that
         # Hessian is identical to that of a full LLLaplace model
         subnetmask_kwargs.update(parameter_names=['1.weight', '1.bias'])
         subnetmask = subnetwork_mask(**subnetmask_kwargs)
@@ -332,7 +332,7 @@ def test_layer_subnet_masks(model, likelihood, subnetwork_mask, class_loader, re
         lap = Laplace(model, likelihood=likelihood, subset_of_weights='subnetwork',
                       subnetwork_indices=subnetmask.indices, hessian_structure=hessian_structure)
         lap.fit(loader)
-        assert lllap.H.equal(lap.H)
+        assert torch.allclose(lllap.H, lap.H, rtol=1e-4)
 
         # define valid parameter name subnet mask
         subnetmask_kwargs.update(parameter_names=['0.weight', '1.bias'])
@@ -377,7 +377,7 @@ def test_layer_subnet_masks(model, likelihood, subnetwork_mask, class_loader, re
         lap = Laplace(model, likelihood=likelihood, subset_of_weights='subnetwork',
                       subnetwork_indices=subnetmask.indices, hessian_structure=hessian_structure)
         lap.fit(loader)
-        assert lllap.H.equal(lap.H)
+        assert torch.allclose(lllap.H, lap.H, rtol=1e-4)
 
         # define valid parameter name subnet mask
         subnetmask_kwargs.update(module_names=['0'])
@@ -396,7 +396,7 @@ def test_layer_subnet_masks(model, likelihood, subnetwork_mask, class_loader, re
         assert isinstance(lap, SubnetLaplace)
 
     elif subnetwork_mask == LastLayerSubnetMask:
-        # should raise error if we pass invalid last-layer name 
+        # should raise error if we pass invalid last-layer name
         subnetmask_kwargs.update(last_layer_name='123')
         with pytest.raises(KeyError):
             subnetmask = subnetwork_mask(**subnetmask_kwargs)
@@ -418,7 +418,7 @@ def test_layer_subnet_masks(model, likelihood, subnetwork_mask, class_loader, re
         assert isinstance(lap, SubnetLaplace)
 
         # check that Hessian is identical to that of a full LLLaplace model
-        assert lllap.H.equal(lap.H)
+        assert torch.allclose(lllap.H, lap.H, rtol=1e-4)
 
         # define valid last-layer subnet mask (with passing the last-layer name)
         subnetmask_kwargs.update(last_layer_name='1')
@@ -437,7 +437,7 @@ def test_layer_subnet_masks(model, likelihood, subnetwork_mask, class_loader, re
         assert isinstance(lap, SubnetLaplace)
 
         # check that Hessian is identical to that of a full LLLaplace model
-        assert lllap.H.equal(lap.H)
+        assert torch.allclose(lllap.H, lap.H, rtol=1e-4)
 
     # check some parameters
     assert subnetmask.indices.equal(lap.backend.subnetwork_indices)
@@ -479,7 +479,7 @@ def test_full_subnet_mask(model, likelihood, class_loader, reg_loader, hessian_s
     full_lap = Laplace(model, likelihood=likelihood, subset_of_weights='all',
                        hessian_structure=hessian_structure)
     full_lap.fit(loader)
-    assert full_lap.H.equal(lap.H)
+    assert torch.allclose(full_lap.H, lap.H, rtol=1e-4)
 
 
 @pytest.mark.parametrize('subnetwork_mask,hessian_structure', product(all_subnet_masks, hessian_structures))
@@ -573,7 +573,7 @@ def test_classification_predictive(model, class_loader, subnetwork_mask, hessian
     assert torch.allclose(f_pred.sum(), torch.tensor(len(f_pred), dtype=torch.double))  # sum up to 1
 
 
-@pytest.mark.parametrize('subnetwork_mask,likelihood,hessian_structure', 
+@pytest.mark.parametrize('subnetwork_mask,likelihood,hessian_structure',
                          product(all_subnet_masks, likelihoods, hessian_structures))
 def test_subnet_marginal_likelihood(model, subnetwork_mask, likelihood, hessian_structure, class_loader, reg_loader):
     subnetmask_kwargs = dict(model=model)


### PR DESCRIPTION
Changelog:
1. Add [Curvlinops](https://github.com/f-dangel/curvlinops/tree/main) backend.
2. Add default `functorch` implementation for many quantities: (in `CurvatureInterface` itself)
    1. Jacobians 
    2. Batch gradients
    3. Diag GGN (both stochastic and exact) and diag EF
    4. Full GGN (both stochastic and exact) and full EF

**Rationale for (1):** BackPACK & ASDL are not actively supported anymore and are hard to extend. Note that we use Curvlinops mainly for KFACs. 

**Rationale for (2):** `functorch` is a first-class PyTorch module => has the highest compatibility to any PyTorch models => futureproofing `laplace-torch`, less dependence to third-party backends

**Together:** They make `laplace-torch` very flexible and compatible with most architectures out there (and in the future).

With this PR, `Laplace(backend=CurvlinopsBackend)` supports:
1. Diag-GGN-exact, diag-GGN-MC, diag-EF for both classification and regression
2. Kron-GGN-exact, kron-GGN-MC, kron-EF for both classification and regression
3. Full-GGN-exact, full-GGN-MC, full-EF, full-Hessian-exact for both classification and regression

Note that previous backends only support some subsets of them.

I'd like to ask @runame to specifically review this since he's involved in Curvlinops. Specifically, for the K-FAC backend proposed here. 