### PR TITLE
Point to curvlinops master branch in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     backpack-for-pytorch
     asdfghjkl
     opt_einsum
-    curvlinops-for-pytorch
+    curvlinops-for-pytorch @ git+https://github.com/f-dangel/curvlinops
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
 python_requires = >=3.8
 


### PR DESCRIPTION
Useful when people do
```
pip install git+https://git@github.com/aleximmer/laplace
```
or 
```
git clone pip install https://github.com/aleximmer/laplace
cd laplace
pip install -e .
```

Addressing #150 