### PR TITLE
Make `CurvatureInterface.functorch_jacobians` simply an alias to `CurvatureInterface.jacobians`

### DIFF
--- a/laplace/baselaplace.py
+++ b/laplace/baselaplace.py
@@ -887,7 +887,7 @@ class ParametricLaplace(BaseLaplace):
             # BackPACK supports backprop through Jacobians, but it interferes with functorch
             Js, f_mu = self.backend.jacobians(X, enable_backprop=self.enable_backprop)
         else:
-            # For ASDL and Curvlinops, we use functorch
+            # For ASDL and Curvlinops, we use functorch (ASDL Jacobians are not backpropable)
             Js, f_mu = self.backend.functorch_jacobians(
                 X, enable_backprop=self.enable_backprop
             )

--- a/laplace/curvature/asdl.py
+++ b/laplace/curvature/asdl.py
@@ -76,7 +76,7 @@ class AsdlInterface(CurvatureInterface):
                 Ji = Ji[:, self.subnetwork_indices]
             Js.append(Ji)
         Js = torch.stack(Js, dim=1)
-        return Js, f
+        return (Js, f) if enable_backprop else (Js.detach(), f.detach())
 
     def gradients(self, x, y):
         """Compute gradients \\(\\nabla_\\theta \\ell(f(x;\\theta, y)\\) at current parameter

--- a/laplace/curvature/curvature.py
+++ b/laplace/curvature/curvature.py
@@ -90,46 +90,6 @@ class CurvatureInterface:
 
         return (Js, f) if enable_backprop else (Js.detach(), f.detach())
 
-    def functorch_jacobians(self, x, enable_backprop=False):
-        """Compute Jacobians \\(\\nabla_\\theta f(x;\\theta)\\) at current parameter \\(\\theta\\).
-
-        Parameters
-        ----------
-        x : torch.Tensor
-            input data `(batch, input_shape)` on compatible device with model.
-        enable_backprop : bool, default = False
-            whether to enable backprop through the Js and f w.r.t. x
-
-        Returns
-        -------
-        Js : torch.Tensor
-            Jacobians `(batch, parameters, outputs)`
-        f : torch.Tensor
-            output function `(batch, outputs)`
-        """
-        # Compute Js
-        # ------------------------
-        params = [p for p in self.model.parameters() if p.requires_grad]
-        name_dict = {p.data_ptr(): name for name, p in self.model.named_parameters()}
-        params_dict = {name_dict[p.data_ptr()]: p for p in params}
-
-        def model_fn_params_only(params_dict):
-            res = torch.func.functional_call(self.model, params_dict, x)
-            return res, res
-
-        # concatenate over flattened parameters
-        Js, f = torch.func.jacrev(model_fn_params_only, has_aux=True)(params_dict)
-        Js = [
-            j.flatten(start_dim=-p.dim())
-            for j, p in zip(Js.values(), params_dict.values())
-        ]
-        Js = torch.cat(Js, dim=-1)
-
-        if self.subnetwork_indices is not None:
-            Js = Js[:, :, self.subnetwork_indices]
-
-        return (Js, f) if enable_backprop else (Js.detach(), f.detach())
-
     def last_layer_jacobians(self, x, enable_backprop=False):
         """Compute Jacobians \\(\\nabla_{\\theta_\\textrm{last}} f(x;\\theta_\\textrm{last})\\)
         only at current last-layer parameter \\(\\theta_{\\textrm{last}}\\).
@@ -264,6 +224,9 @@ class CurvatureInterface:
             vector representing the diagonal of H
         """
         raise NotImplementedError
+
+    # Aliasing `jacobians` so that it can be accessed even if overloaded by subclasses
+    functorch_jacobians = jacobians
 
 
 class GGNInterface(CurvatureInterface):

--- a/tests/test_baselaplace.py
+++ b/tests/test_baselaplace.py
@@ -574,7 +574,9 @@ def test_reward_modeling(laplace, reward_model, reward_loader, reward_test_X):
 
 
 @pytest.mark.parametrize('laplace', [KronLaplace, DiagLaplace])
-@pytest.mark.parametrize('backend', [AsdlEF, AsdlGGN, CurvlinopsEF, CurvlinopsGGN])
+@pytest.mark.parametrize(
+    'backend', [AsdlEF, AsdlGGN, AsdfghjklGGN, AsdfghjklEF, CurvlinopsEF, CurvlinopsGGN]
+)
 def test_dict_data(laplace, backend, custom_model, custom_loader):
     if laplace == DiagLaplace and backend == CurvlinopsEF:
         pytest.skip(
@@ -605,7 +607,8 @@ def test_dict_data(laplace, backend, custom_model, custom_loader):
 
 @pytest.mark.parametrize('laplace', [FullLaplace, KronLaplace, DiagLaplace])
 @pytest.mark.parametrize(
-    'backend', [BackPackGGN, AsdlGGN, AsdlEF, CurvlinopsGGN, CurvlinopsEF]
+    'backend',
+    [BackPackGGN, AsdlGGN, AsdlEF, CurvlinopsGGN, CurvlinopsEF],
 )
 def test_backprop_glm(laplace, model, reg_loader, backend):
     X, y = reg_loader.dataset.tensors


### PR DESCRIPTION
Before, they were duplicates. The rationale is to make `functorch_jacobians` accessible even when the subclasses overloaded `jacobians`. Useful for Bayesian optimization since not all backend's `jacobians` are backpropable (e.g. ASDL detaches everything).