### PR TITLE
Remove depreciated `loss_average` argument of `KFACLinearOperator` and add makefile for ruff

### DIFF
--- a/laplace/curvature/curvlinops.py
+++ b/laplace/curvature/curvlinops.py
@@ -4,6 +4,7 @@ import torch
 from curvlinops import (
     EFLinearOperator,
     FisherMCLinearOperator,
+    FisherType,
     GGNLinearOperator,
     HessianLinearOperator,
     KFACLinearOperator,
@@ -143,7 +144,7 @@ class CurvlinopsGGN(CurvlinopsInterface, GGNInterface):
 
     @property
     def _kron_fisher_type(self):
-        return "mc" if self.stochastic else "type-2"
+        return FisherType.MC if self.stochastic else FisherType.TYPE2
 
     @property
     def _linop_context(self):
@@ -155,7 +156,7 @@ class CurvlinopsEF(CurvlinopsInterface, EFInterface):
 
     @property
     def _kron_fisher_type(self):
-        return "empirical"
+        return FisherType.EMPIRICAL
 
     @property
     def _linop_context(self):

--- a/laplace/curvature/curvlinops.py
+++ b/laplace/curvature/curvlinops.py
@@ -79,7 +79,6 @@ class CurvlinopsInterface(CurvatureInterface):
             self.params,
             [(X, y)],
             fisher_type=self._kron_fisher_type,
-            loss_average=None,  # Since self.lossfunc is sum
             separate_weight_and_bias=True,
             check_deterministic=False,  # To avoid overhead
             # `kwargs` for `mc_samples` when `stochastic=True` and `kfac_approx` to

--- a/makefile
+++ b/makefile
@@ -1,0 +1,3 @@
+ruff:
+	-ruff check --fix
+	@ruff format

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,12 @@ exclude = tests*
 ###############################################################################
 
 [options.extras_require]
+# Dependencies needed for development  (semicolon/line-separated)
+dev =
+    ruff
+    %(tests)s
+    %(docs)s
+
 # Dependencies needed to run the tests  (semicolon/line-separated)
 tests =
     pytest
@@ -63,4 +69,3 @@ tests =
 docs =
     matplotlib
     pdoc3
-


### PR DESCRIPTION
The `loss_average` argument of `KFACLinearOperator` in `curvlinops` was just removed [here](https://github.com/f-dangel/curvlinops/pull/117). Hence, I removed the single use of this argument in this repo.

Also, I added a makefile to bundle both ruff commands into one (`make ruff`) since this is a very common workflow.