### PR TITLE
Refactor reward-modeling likelihood

### DIFF
--- a/laplace/utils/utils.py
+++ b/laplace/utils/utils.py
@@ -35,7 +35,6 @@ def validate(
     pred_type="glm",
     link_approx="probit",
     n_samples=100,
-    loss_with_var=False,
     dict_key_y="labels",
 ) -> float:
     laplace.model.eval()


### PR DESCRIPTION
Suggested refactor of the reward-modeling likelihood, let me know if I missed something. Advantages:

1. Simplicity and readability. We get rid of `self.reward_modeling` and `self._fitting` (actually `self._fitting` was not even used before, not sure if you had a future use case in mind?).
2. When a user calls `la.likelihood` it will always return `"reward_modeling"` which should be the expected behavior.

(Unrelated: I also removed a superfluous `loss_with_var` argument.)