### PR TITLE
Add `py.typed` to the package to enable the type annotations

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,6 @@ classifiers =
 [options]
 zip_safe = False
 packages = find:
-include_package_data = True
 setup_requires =
   setuptools_scm
 # Dependencies of the project (semicolon/line-separated):
@@ -47,6 +46,10 @@ python_requires = >=3.9
 
 [options.packages.find]
 exclude = tests*
+
+[options.package_data]
+laplace =
+    py.typed
 
 ###############################################################################
 #                           Development dependencies                          #


### PR DESCRIPTION
According to [PEP 561], packages with inline type annotations should put a `py.typed` marker file in their package directory. This fixes mypy [`import-untyped`] errors when type checking code which imports `laplace`:

```
error: Skipping analyzing "laplace": module is installed, but missing library stubs or py.typed marker.
    from laplace import Laplace
    ^
note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
```

[PEP 561]: https://peps.python.org/pep-0561/#packaging-type-information
[`import-untyped`]: https://mypy.readthedocs.io/en/stable/error_code_list.html#check-that-import-target-can-be-found-import-untyped