### PR TITLE
Fix `sigma_noise` gradient propagation in `BaseLaplace.log_likelihood`

### DIFF
--- a/laplace/baselaplace.py
+++ b/laplace/baselaplace.py
@@ -223,7 +223,7 @@ class BaseLaplace:
             c = (
                 self.n_data
                 * self.n_outputs
-                * torch.log(torch.tensor(self.sigma_noise) * sqrt(2 * pi))
+                * torch.log(torch.as_tensor(self.sigma_noise) * sqrt(2 * pi))
             )
             return factor * self.loss - c
         else:


### PR DESCRIPTION
Commit 1eea27c introduces type hints in `baselaplace.py` but breaks the gradient flow through `BaseLaplace.log_likelihood(...)` since `sigma_noise` loses its gradient via [`torch.tensor(...)`]. 

This is fixed by using [`torch.as_tensor(...)`] as it converts floats but preserves the gradient. (See highlighted note [here](https://pytorch.org/docs/stable/generated/torch.tensor.html#:~:text=preserves%20autograd%20history).)

This change fixes the `UserWarning` below and passes type checking with Pylance.
```
laplace/baselaplace.py:226: UserWarning: To copy construct from a tensor, it is recommended to use
[...], rather than torch.tensor(sourceTensor).
```

[`torch.tensor(...)`]: https://pytorch.org/docs/stable/generated/torch.tensor.html
[`torch.as_tensor(...)`]: https://pytorch.org/docs/stable/generated/torch.as_tensor.html