### PR TITLE
Fix bug in `FullLaplace.sample` (refer to Issue #268)

### DIFF
--- a/laplace/baselaplace.py
+++ b/laplace/baselaplace.py
@@ -1643,7 +1643,7 @@ class FullLaplace(ParametricLaplace):
             generator=generator,
         )
         # (n_samples, n_params) x (n_params, n_params) -> (n_samples, n_params)
-        samples = samples @ self.posterior_scale
+        samples = samples @ self.posterior_scale.T
         return self.mean.reshape(1, self.n_params) + samples
 
 


### PR DESCRIPTION
This pull request fixes a bug in the full `FullLaplace.sample` function, by changing $samples @ scale \rightarrow samples @ scale^{\top}$ which coincides with the remaining code. The bug is discussed in Issue #268.