### PR TITLE
Fix subnet samples (`posterior_scale.T` issue)

### DIFF
--- a/laplace/subnetlaplace.py
+++ b/laplace/subnetlaplace.py
@@ -200,7 +200,7 @@ class FullSubnetLaplace(SubnetLaplace, FullLaplace):
             dtype=self._dtype,
             generator=generator,
         )
-        subnet_samples = self.mean_subnet[None, ...] + samples @ self.posterior_scale
+        subnet_samples = self.mean_subnet[None, ...] + samples @ self.posterior_scale.T
         return self.assemble_full_samples(subnet_samples)
 
 

--- a/tests/test_baselaplace.py
+++ b/tests/test_baselaplace.py
@@ -384,16 +384,6 @@ def test_laplace_functionality(laplace, lh, model, reg_loader, class_loader):
     lml = lml + 1 / 2 * (prior_prec.logdet() - log_det_post_prec)
     assert torch.allclose(lml, lap.log_marginal_likelihood())
 
-    # test sampling
-    torch.manual_seed(61)
-    samples = lap.sample(n_samples=1)
-    assert samples.shape == torch.Size([1, len(theta)])
-    samples = lap.sample(n_samples=1000000)
-    assert samples.shape == torch.Size([1000000, len(theta)])
-    mu_comp = samples.mean(dim=0)
-    mu_true = lap.mean
-    assert torch.allclose(mu_comp, mu_true, atol=1e-2)
-
     # test functional variance
     if laplace == FullLaplace:
         Sigma = lap.posterior_covariance
@@ -408,6 +398,15 @@ def test_laplace_functionality(laplace, lh, model, reg_loader, class_loader):
     true_f_var = torch.einsum("mkp,pq,mcq->mkc", Js, Sigma, Js)
     comp_f_var = lap.functional_variance(Js)
     assert torch.allclose(true_f_var, comp_f_var, rtol=1e-4)
+
+    # test sampling
+    torch.manual_seed(61)
+    samples = lap.sample(n_samples=1)
+    assert samples.shape == torch.Size([1, len(theta)])
+    samples = lap.sample(n_samples=1_000_000)
+    assert samples.shape == torch.Size([1_000_000, len(theta)])
+    assert torch.allclose(samples.mean(dim=0), lap.mean, rtol=0, atol=1e-2)
+    assert torch.allclose(samples.T.cov(), Sigma, rtol=0, atol=1e-2)
 
 
 @pytest.mark.parametrize("laplace", online_flavors)

--- a/tests/test_lllaplace.py
+++ b/tests/test_lllaplace.py
@@ -440,16 +440,6 @@ def test_laplace_functionality(
     lml = lml + 1 / 2 * (prior_prec.logdet() - log_det_post_prec)
     assert torch.allclose(lml, lap.log_marginal_likelihood())
 
-    # test sampling
-    torch.manual_seed(61)
-    samples = lap.sample(n_samples=1)
-    assert samples.shape == torch.Size([1, len(theta)])
-    samples = lap.sample(n_samples=1000000)
-    assert samples.shape == torch.Size([1000000, len(theta)])
-    mu_comp = samples.mean(dim=0)
-    mu_true = lap.mean
-    assert torch.allclose(mu_comp, mu_true, atol=1e-2)
-
     # test functional variance
     if laplace == FullLLLaplace:
         Sigma = lap.posterior_covariance
@@ -466,6 +456,15 @@ def test_laplace_functionality(
     assert torch.allclose(f, comp_f)
     comp_f_var = lap.functional_variance(comp_Js)
     assert torch.allclose(true_f_var, comp_f_var, rtol=1e-4)
+
+    # test sampling
+    torch.manual_seed(61)
+    samples = lap.sample(n_samples=1)
+    assert samples.shape == torch.Size([1, len(theta)])
+    samples = lap.sample(n_samples=1_000_000)
+    assert samples.shape == torch.Size([1_000_000, len(theta)])
+    assert torch.allclose(samples.mean(dim=0), lap.mean, rtol=0, atol=1e-2)
+    assert torch.allclose(samples.T.cov(), Sigma, rtol=0, atol=1e-2)
 
 
 @pytest.mark.parametrize("laplace", flavors)

--- a/tests/test_subnetlaplace.py
+++ b/tests/test_subnetlaplace.py
@@ -869,7 +869,8 @@ def test_subnet_marginal_likelihood(
 def test_sample(model, likelihood, hessian_structure, class_loader, reg_loader):
     loader = class_loader if likelihood == "classification" else reg_loader
 
-    subnetmask = RandomSubnetMask(model=model, n_params_subnet=10)
+    n_params_subnet = 10
+    subnetmask = RandomSubnetMask(model=model, n_params_subnet=n_params_subnet)
     subnetmask.select()
 
     lap = Laplace(
@@ -914,6 +915,28 @@ def test_sample(model, likelihood, hessian_structure, class_loader, reg_loader):
     assert not (
         samples_1[:, ~fixed_mask] == model_params[~fixed_mask].repeat(n_samples, 1)
     ).all()
+
+    # Make sure empirical cov/var of samples matches posterior_covariance
+    # (full) / posterior_variance (diag). Since the internal posterior_*
+    # quantities are of shape (n_params_subnet, n_params_subnet) /
+    # (n_params_subnet,), we calculate the (co)variance of the active
+    # parameters only.
+    n_samples = int(1e6)
+    samples = lap.sample(n_samples=n_samples)[:, ~fixed_mask]
+    if hessian_structure == "full":
+        assert lap.posterior_scale.shape == (n_params_subnet, n_params_subnet)
+        assert lap.posterior_covariance.shape == (n_params_subnet, n_params_subnet)
+        assert torch.allclose(
+            lap.posterior_covariance, samples.T.cov(), rtol=0, atol=1e-2
+        )
+    elif hessian_structure == "diag":
+        assert lap.posterior_scale.shape == (n_params_subnet,)
+        assert lap.posterior_variance.shape == (n_params_subnet,)
+        assert torch.allclose(
+            lap.posterior_variance, samples.var(axis=0), rtol=0, atol=1e-2
+        )
+    else:
+        raise ValueError(f"{hessian_structure=} not supported")
 
 
 @pytest.mark.parametrize("laplace", [FullSubnetLaplace, DiagSubnetLaplace])


### PR DESCRIPTION
Closes #274 

This fixes the `posterior_scale.T` issue discusssed in #274 (`FullSubnetLaplace.sample()`) and adds tests to make sure `FullSubnetLaplace.sample()` and `DiagSubnetLaplace.sample()` do the right thing. 

We also add cov sampling tests for all other Laplace variants in `tests/test_baselaplace.py` and `tests/test_lllaplace.py`.